### PR TITLE
Point to the CH infra spec for Fetch integration

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -196,17 +196,6 @@ The header's ABNF is:
   Sec-CH-Arch = sh-string
 ~~~
 
-To <dfn abstract-op local-lt="set-arch">set the `Sec-CH-Arch` header for a request</dfn>, given a [=request=] (|r|),
-user agents MUST:
-
-1.  If |r|'s [=request/client-hints set=] [=list/contains=] `Arch`, then:
-
-    1.  Let `value` be a [=Structured Header=] object whose value is the user agent's
-        [=user agent/platform architecture=].
-
-    2.  [=header list/Set a structured header=] in |r|'s [=request/header list=] whose name is
-        `Sec-CH-Arch`, and whose value is `value`.
-
 
 The 'Sec-CH-Model' Header Field {#sec-ch-model}
 -------------------------------
@@ -220,17 +209,6 @@ The header's ABNF is:
 ``` abnf
   Sec-CH-Model = sh-string
 ```
-
-To <dfn abstract-op local-lt="set-model">set the `Sec-CH-Model` header for a request</dfn>, given a [=request=] (|r|),
-user agents MUST:
-
-1.  If |r|'s [=request/client-hints set=] [=list/contains=] `Model`, then:
-
-    1.  Let `value` be a [=Structured Header=] object whose value is the user agent's
-        [=user agent/model=].
-
-    2.  [=header list/Set a structured header=] in |r|'s [=request/header list=] whose name is
-        `Sec-CH-Model`, and whose value is `value`.
 
 ISSUE(wicg/ua-client-hints): Perhaps `Sec-CH-Mobile` is enough, and we don't need to expose the model?
 
@@ -279,7 +257,7 @@ are fairly clearly sniffable by "examining the structure of other headers and by
 availability and semantics of the features introduced or modified between releases of a particular
 browser" [[Janc2014]]).
 
-To <dfn abstract-op local-lt="set-ua">set the `Sec-CH-UA` header for a request</dfn>, given a [=request=] (|r|),
+To <dfn abstract-op local-lt="set-ua">return the `Sec-CH-UA` value for a request</dfn>, given a [=request=] (|r|),
 user agents MUST:
 
 1.  Let |value| be a [=Structured Header=] object whose value is a [=structured header/list=].
@@ -305,8 +283,7 @@ user agents MUST:
 
     Note: See [[#grease]] for more details on why these steps might be appropriate.
 
-6.  [=header list/Set a structured header=] in |r|'s [=request/header list=] whose name is
-    `Sec-CH-UA`, and whose value is |value|.
+6.  Return |value|.
 
 The 'Sec-CH-Mobile' Header Field {#sec-ch-mobile}
 --------------------------------
@@ -321,39 +298,10 @@ The header's ABNF is:
   Sec-CH-Mobile = sh-boolean
 ```
 
-To <dfn abstract-op local-lt="set-mobile">set the `Sec-CH-Mobile` header for a request</dfn>, given a [=request=] (|r|),
-user agents MUST:
-
-1.  If the |r|'s [=request/client-hints set=] [=list/contains=] `Mobile`, then:
-
-    1.  Let `value` be a [=Structured Header=] whose value is the user agent's
-        [=user agent/mobileness=].
-
-    2.  [=header list/Set a structured header=] in |r|'s [=request/header list=] whose name is
-        `Sec-CH-Mobile`, and whose value is `value`.
-
 
 Integration with Fetch {#fetch-integration}
 ----------------------
-
-The Fetch specification should call into the following algorithm in place of the current Step 5.11
-in its HTTP-network-or-cache fetch algorithm.
-
-To <dfn abstract-op export>set the user agent metadata for a request</dfn> (|r|), the user agent MUST
-execute the following steps:
-
-1.  If |r|'s [=request/header list=] does not [=header list/contain=] `User-Agent`, then the user
-    agent MAY append `User-Agent`/[=default `User-Agent` value=] to |r|'s [=request/header list=].
-
-2.  <a abstract-op lt="set-arch">Set the `Sec-CH-Arch` header for a request</a>, given |r|.
-
-3.  <a abstract-op lt="set-mobile">Set the `Sec-CH-Mobile` header for a request</a>, given |r|.
-
-3.  <a abstract-op lt="set-model">Set the `Sec-CH-Model` header for a request</a>, given |r|.
-
-4.  <a abstract-op lt="set-platform">Set the `Sec-CH-Platform` header for a request</a>, given |r|.
-
-5.  <a abstract-op lt="set-ua">Set the `Sec-CH-UA` header for a request</a>, given |r|.
+Fetch integration of this specification is defined as part of the <a href="https://wicg.github.io/client-hints-infrastructure/#fetch">Client Hints infrastructure</a> specification.
 
 
 Interface {#interface} 
@@ -419,23 +367,11 @@ of a given agent's behavior over time.
 Delegation {#delegation}
 ----------
 
-Client Hints will be delegated from top-level pages via Feature Policy (once a few patches against
-Fetch and Client Hints and Feature Policy land). This reduces the likelihood that user agent
+Client Hints will be delegated from top-level pages via Feature Policy. This reduces the likelihood that user agent
 information will be delivered along with subresource requests, which reduces the potential for
-passive fingerprinting. The following issues cover the dependencies:
+passive fingerprinting.
 
-ISSUE(whatwg/fetch#773): Fetch integration of Accept-CH opt-in, and the definition of a
-[=request=]'s <dfn for="request">client-hints set</dfn>.
-
-ISSUE(whatwg/html#3774): HTML integration of Accept-CH-Lifetime and the ACHL cache.
-
-ISSUE(whatwg/fetch#725): Adding new CH features to the CH list in Fetch
-
-ISSUE(whatwg/fetch#811): 3rd-party opt-in
-
-ISSUE(wicg/feature-policy#220): 3rd-party opt-in
-
-ISSUE: These are all out of date. Yoav will fix them.
+That delegation is defined as part of [=append client hints to request=].
 
 Access Restrictions {#access}
 -------------------

--- a/index.bs
+++ b/index.bs
@@ -226,17 +226,6 @@ The header's ABNF is:
   Sec-CH-Platform = sh-string
 ```
 
-To <dfn abstract-op local-lt="set-platform">set the `Sec-CH-Platform` header for a request</dfn>, given a [=request=] (|r|),
-user agents MUST:
-
-1.  If |r|'s [=request/client-hints set=] [=list/contains=] `Platform`, then:
-
-    1.  Let `value` be a [=Structured Header=] object whose value is the user agent's
-        [=user agent/platform brand and version=].
-
-    2.  [=header list/Set a structured header=] in |r|'s [=request/header list=] whose name is
-        `Sec-CH-Platform`, and whose value is `value`.
-
 The 'Sec-CH-UA' Header Field {#sec-ch-ua}
 ----------------------------
 
@@ -257,14 +246,14 @@ are fairly clearly sniffable by "examining the structure of other headers and by
 availability and semantics of the features introduced or modified between releases of a particular
 browser" [[Janc2014]]).
 
-To <dfn abstract-op local-lt="set-ua">return the `Sec-CH-UA` value for a request</dfn>, given a [=request=] (|r|),
+To <dfn abstract-op local-lt="set-ua">return the `Sec-CH-UA` value for a request</dfn>, given a
+<a href="https://wicg.github.io/client-hints-infrastructure/#environment-settings-object-client-hints-set">client hints set</a> (|set|),
 user agents MUST:
 
 1.  Let |value| be a [=Structured Header=] object whose value is a [=structured header/list=].
 
-2.  Let |version| be the user agent's [=user agent/full version=] if |r|'s
-    [=request/client-hints set=] [=list/contains=] `UA`, and the user agent's
-    [=user agent/major version=] otherwise.
+2.  Let |version| be the user agent's [=user agent/full version=] if |set|
+    [=list/contains=] `UA`, and the user agent's [=user agent/major version=] otherwise.
 
 3.  Let |ua| be a string whose value is the [=string/concatenation=] of the user agent's
     [=user agent/brand=], a U+0020 SPACE character, and |version|.
@@ -371,7 +360,7 @@ Client Hints will be delegated from top-level pages via Feature Policy. This red
 information will be delivered along with subresource requests, which reduces the potential for
 passive fingerprinting.
 
-That delegation is defined as part of [=append client hints to request=].
+That delegation is defined as part of <a href="https://wicg.github.io/client-hints-infrastructure/#abstract-opdef-append-client-hints-to-request">append client hints to request</a>.
 
 Access Restrictions {#access}
 -------------------


### PR DESCRIPTION
This PR removes Fetch integration from this spec, as it's also defined in https://wicg.github.io/client-hints-infrastructure/#fetch
It also modifies the algorithm to calculate the UA value, which I'll need to call from the infrastructure spec.