### PR TITLE
Add a "full version" hint

### DIFF
--- a/.pr-preview.json
+++ b/.pr-preview.json
@@ -1,0 +1,6 @@
+{
+    "src_file": "index.bs",
+    "type": "bikeshed",
+    "params": {
+    }
+}

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ accomplish this as follows:
     2.  The `Sec-CH-UA-Platform` header field represents the platform's brand and major version. For example:
 
         ```http
-        Sec-CH-UA-Platform: "Win"; v="10"
+        Sec-CH-UA-Platform: "Windows"
         ```
 
     3.  The `Sec-CH-UA-Arch` header field represents the underlying architecture's instruction set and
@@ -149,7 +149,8 @@ accomplish this as follows:
     interface NavigatorUAData {
       readonly attribute FrozenArray<NavigatorUABrandVersionDict> brand;   // [ { brand: "Chrome", version: "69" } ]
       readonly attribute boolean mobile;                                   // false
-      Promise<NavigatorUABrandVersionDict> getPlatform();                  // { brand: "Win", version: "10" }
+      Promise<DOMString> getPlatform();                                    // "Windows"
+      Promise<DOMString> getPlatformVersion();                             // "10"
       Promise<DOMString> getArchitecture();                                // "ARM64"
       Promise<DOMString> model();                                          // ""
     };
@@ -192,7 +193,7 @@ Then subsequent requests to `https://example.com` will include the following req
 User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko)
             Chrome/71.1.2222.33 Safari/537.36
 Sec-CH-UA: "Chrome"; v="74.0.3424.124"
-Sec-CH-UA-Platform: "macOS"; v="12"
+Sec-CH-UA-Platform: "macOS"
 Sec-CH-UA-Arch: "ARM64"
 ```
 

--- a/README.md
+++ b/README.md
@@ -500,7 +500,7 @@ CORS preflights. A `Sec-CH-` prefix seems like a viable approach.
 
 ## How does `Sec-CH-UA-Mobile` define "mobile"?
 
-This is a tough question. The motiviation for the header is that a majority of user-agent header 
+This is a tough question. The motivation for the header is that a majority of user-agent header 
 sniffing is used by the server to decide if a "desktop" or "mobile" UX should be served. This is
 currently implicitly defined in most modern browsers because they have two distinct UIs, a 
 "desktop" version (i.e. Windows, Mac OS, etc.) and a "mobile" version (i.e. Android, iOS). In general,

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ accomplish this as follows:
 
 3.  Browsers should introduce several new Client Hint header fields:
 
-    1.  The `Sec-UA` header field represents the user agent's brand and significant version. For example:
+    1.  The `Sec-CH-UA` header field represents the user agent's brand and significant version. For example:
 
         ```http
         Sec-CH-UA: "Chrome"; v="73"

--- a/index.bs
+++ b/index.bs
@@ -153,14 +153,15 @@ asks for a little more information by sending an `Accept-CH` header (Section 2.2
 [[I-D.ietf-httpbis-client-hints]]) along with the initial response:
 
 ``` http
-  Accept-CH: UA, Platform
+  Accept-CH: UA-Full-Version, UA-Platform
 ```
 
 In response, the user agent includes more detailed version information, as well as information about
 the underlying platform in the next request:
 
 ``` http
-  Sec-CH-UA: "Examplary Browser"; v="73.3R8.2H.1"
+  Sec-CH-UA: "Examplary Browser"; v="73"
+  Sec-CH-UA-Full-Version: "73.3R8.2H.1"
   Sec-CH-UA-Platform: "Windows"
 ```
 
@@ -259,12 +260,14 @@ The header's ABNF is:
   Sec-CH-UA = sh-list
 ```
 
-Unlike most Client Hints, the `Sec-CH-UA` header will be sent with all requests, whether or not the
-server opted-into receiving the header via an `Accept-CH` header. Prior to an opt-in, however, it
-will include only the [=user agent=]'s branding information, and the significant version number (both of which
-are fairly clearly sniffable by "examining the structure of other headers and by testing for the
-availability and semantics of the features introduced or modified between releases of a particular
-browser" [[Janc2014]]).
+Unlike most Client Hints, since it's included in the <a
+href="https://wicg.github.io/client-hints-infrastructure/#low-entropy-table">low-entropy table</a>,
+the `Sec-CH-UA` header will be sent with all requests, whether or not the server opted-into
+receiving the header via an `Accept-CH` header. Therefore, it includes only the [=user agent=]'s
+branding information, and the significant version number (both of which are fairly clearly
+sniffable by "examining the structure of other headers and by testing for the availability and
+semantics of the features introduced or modified between releases of a particular browser"
+[[Janc2014]]).
 
 To <dfn abstract-op local-lt="set-ua">return the `Sec-CH-UA` value for a request</dfn>, given a
 <a href="https://wicg.github.io/client-hints-infrastructure/#environment-settings-object-client-hints-set">client hints set</a> (|set|),
@@ -272,8 +275,7 @@ To <dfn abstract-op local-lt="set-ua">return the `Sec-CH-UA` value for a request
 
 1.  Let |value| be a [=Structured Header=] object whose value is a [=structured header/list=].
 
-2.  Let |version| be the [=user agent=]'s [=user agent/full version=] if |set|
-    [=list/contains=] `UA`, and the [=user agent=]'s [=user agent/significant version=] otherwise.
+2.  Let |version| be the [=user agent=]'s [=user agent/significant version=].
 
 3.  Let |ua| be a string whose value is the [=string/concatenation=] of the [=user agent=]'s
     [=user agent/brand=], the string ";v=", and |version|.

--- a/index.bs
+++ b/index.bs
@@ -339,11 +339,11 @@ dictionary NavigatorUABrandVersion {
 };
 
 dictionary UADataValues {
-  DOMString platform; 
-  DOMString platformVersion;
-  DOMString architecture;
-  DOMString model;
-  DOMString uaFullVersion;
+  DOMString platform = ""; 
+  DOMString platformVersion = "";
+  DOMString architecture = "";
+  DOMString model = "";
+  DOMString uaFullVersion = "";
 };
 
 [Exposed=Window]

--- a/index.bs
+++ b/index.bs
@@ -269,8 +269,7 @@ sniffable by "examining the structure of other headers and by testing for the av
 semantics of the features introduced or modified between releases of a particular browser"
 [[Janc2014]]).
 
-To <dfn abstract-op local-lt="set-ua">return the `Sec-CH-UA` value for a request</dfn>, given a
-<a href="https://wicg.github.io/client-hints-infrastructure/#environment-settings-object-client-hints-set">client hints set</a> (|set|),
+To <dfn abstract-op local-lt="set-ua">return the `Sec-CH-UA` value for a request</dfn>,
 [=user agents=] MUST:
 
 1.  Let |value| be a [=Structured Header=] object whose value is a [=structured header/list=].
@@ -339,11 +338,11 @@ dictionary NavigatorUABrandVersion {
 };
 
 dictionary UADataValues {
-  DOMString platform = ""; 
-  DOMString platformVersion = "";
-  DOMString architecture = "";
-  DOMString model = "";
-  DOMString uaFullVersion = "";
+  DOMString platform; 
+  DOMString platformVersion;
+  DOMString architecture;
+  DOMString model;
+  DOMString uaFullVersion;
 };
 
 [Exposed=Window]

--- a/index.bs
+++ b/index.bs
@@ -632,6 +632,24 @@ Author/Change controller:
 Specification document:
 : this specification ([[#sec-ch-mobile]])
 
+'Sec-CH-UA-Full-Version' Header Field {#iana-full-version}
+----------------------------
+
+Header field name:
+: Sec-CH-UA-Full-Version
+
+Applicable protocol:
+: http
+
+Status:
+: standard
+
+Author/Change controller:
+: IETF
+
+Specification document:
+: this specification ([[#sec-ch-full-version]])
+
 'User-Agent' Header Field {#iana-user-agent}
 -------------------------
 

--- a/index.bs
+++ b/index.bs
@@ -34,6 +34,7 @@ urlPrefix: https://tools.ietf.org/html/draft-ietf-httpbis-header-structure; spec
             text: list; url: #section-3.1
     type: abstract-op
         text: serialize Structured Header; url: #section-4.1
+    spec:infra; type:dfn; for:/; text:list
 </pre>
 <pre class="biblio">
 {
@@ -316,23 +317,27 @@ Interface {#interface}
 =================
 
 <pre class="idl">
-dictionary NavigatorUABrandVersionDict {
-  required DOMString brand;
+dictionary NavigatorUABrandVersion {
+  DOMString brand;
   DOMString version;
+};
+
+dictionary UADataValues {
+  DOMString platform; 
+  DOMString platformVersion;
+  DOMString architecture;
+  DOMString model;
 };
 
 [Exposed=Window]
 interface NavigatorUAData {
-  readonly attribute FrozenArray&lt;NavigatorUABrandVersionDict&gt; brand;
+  readonly attribute FrozenArray&lt;NavigatorUABrandVersion&gt; uaList;
   readonly attribute boolean mobile;
-  Promise&lt;DOMString&gt; getPlatform();
-  Promise&lt;SOMString&gt; getPlatformVersion();
-  Promise&lt;DOMString&gt; getArchitecture();
-  Promise&lt;DOMString&gt; getModel();
+  Promise&lt;UADataValues&gt; getHighEntropyValues(sequence&lt;DOMString&gt; hints);
 };
 
 interface mixin NavigatorUA {
-  [SecureContext] NavigatorUAData getUserAgent();
+  [SecureContext] readonly attribute NavigatorUAData userAgentData;
 };
 Navigator includes NavigatorUA;
 
@@ -340,32 +345,68 @@ Navigator includes NavigatorUA;
 
 Processing model {#processing}
 --------------
-<dfn method for="NavigatorUA"><code>getUserAgent()</code></dfn> method MUST run these steps:
+
+<h3 id="monkeypatch-html-windoworworkerglobalscope"><code>WindowOrWorkerGlobalScope</code></h3>
+
+Each [=user agent=] has an associated <dfn>UA list</dfn>, which is a [=/list=] created by running [=create UA list=].
+
+Every {{WindowOrWorkerGlobalScope}} object has an associated <dfn for="WindowOrWorkerGlobalScope">UA frozen array</dfn>, which is a <code><a interface>FrozenArray</a>&lt;<a dictionary>NavigatorUABrandVersion</a>></code>. It is initially the result of [=create a frozen array|creating a frozen array=] from the [=user agent=]'s [=UA list=].
+
+<h3 id="create-ua-list-section">Create a UA list</h3>
+
+When asked to run the <dfn>create UA list</dfn> algorithm, the user agent MUST run the following steps:
+1. Let |list| be a [=/list=].
+
+2. Collect pairs of [=user agent/brand=] and [=user agent/significant version=] which represent the user agent,
+    its equivalence class and/or its rendering engine.
+
+3. For each pair:
+
+    1. Let |dict| be a new {{NavigatorUABrandVersion}} dictionary,
+        with [=user agent/brand=] as {{NavigatorUABrandVersion/brand}} and [=user agent/significant version=] as {{NavigatorUABrandVersion/version}}. 
+
+    2. Append |dict| to |list|.
+
+4.  The user agent MAY execute the following steps:
+
+    1.  [=list/Append=] additional items to |list| containing {{NavigatorUABrandVersion}} objects,
+        initialized with arbitrary {{NavigatorUABrandVersion/brand}} and {{NavigatorUABrandVersion/version}} combinations.
+
+    2.  Randomize the order of the items in |list|.
+
+    Note: See [[#grease]] for more details on why these steps might be appropriate.
+
+5. Return |list|.
+
+<h3 id="getters">Getters</h3>
+
+On getting, the {{NavigatorUAData/uaList}} attribute MUST return [=this=]'s [=relevant global object=]'s [=WindowOrWorkerGlobalScope/UA frozen array=].
+
+On getting, the {{NavigatorUAData/mobile}} attribute must return the user agent's [=user agent/mobileness=].
+
+<h3 id="getHighEntropyValues"><code>getHighEntropyValues</code> method</h3>
+
+The <dfn method for="NavigatorUA"><code>getHighEntropyValues(|hints|)</code></dfn> method MUST run these steps:
 
 1. Let |p| be a [=a new promise=].
 
 2.  Run the following steps [=in parallel=]:
 
-    1.  Let |UAData| be a new {{NavigatorUAData}} object whose values are initialized as follows:
+    1. Let |uaData| be a new {{UADataValues}}.
 
-        :   {{NavigatorUAData/brand}}
-        ::  The user agent's [=user agent/brand=].
-        :   {{NavigatorUAData/getPlatform}}
-        ::  The user agent's [=user agent/platform brand=].
-        :   {{NavigatorUAData/getPlatformVersion}}
-        ::  The user agent's [=user agent/platform version=].
-        :   {{NavigatorUAData/getArchitecture}}
-        ::  The user agent's [=user agent/platform architecture=].
-        :   {{NavigatorUAData/getModel}}
-        ::  The user agent's [=user agent/model=].
-        :   {{NavigatorUAData/mobile}}
-        ::  The user agent's [=user agent/mobileness=].
+    2. If |hints| [=contains=] "platform", set |uaData|["{{UADataValues/platform}}"] to the user agent's [=user agent/platform brand=].
 
-    2.  [=Resolve=] |p| with |UAData|.
+    3. If |hints| [=contains=] "platformVersion", set |uaData|["{{UADataValues/platformVersion}}"] to the user agent's [=user agent/platform version=].
+
+    4. If |hints| [=contains=] "architecture", set |uaData|["{{UADataValues/architecture}}"] to the user agent's [=user agent/platform architecture=].
+
+    5. If |hints| [=contains=] "model", set |uaData|["{{UADataValues/model}}"] to the user agent's [=user agent/model=].
+
+    6. [=Queue a task=] to [=resolve=] |p| with |uaData|.
+
+ISSUE: Add a specific task source this is queued on.
 
 3.  Return |p|.
-
-ISSUE: Provide a method to only access the UA's significant version.
 
 Security and Privacy Considerations {#security-privacy}
 ===================================
@@ -590,4 +631,3 @@ Author/Change controller:
 
 Specification document:
 : this specification ([[#user-agent]]), and Section 5.5.3 of [[RFC7231]]
-

--- a/index.bs
+++ b/index.bs
@@ -159,7 +159,7 @@ the underlying platform in the next request:
 
 ``` http
   Sec-CH-UA: "Examplary Browser"; v="73.3R8.2H.1"
-  Sec-CH-UA-Platform: "Windows"; v="10"
+  Sec-CH-UA-Platform: "Windows"
 ```
 
 
@@ -174,7 +174,8 @@ a number of properties for itself:
 *   <dfn for="user agent" export>brand</dfn> (for example: "cURL", "Edge", "The World's Best Web Browser")
 *   <dfn for="user agent" export>significant version</dfn> (for example: "72", "3", or "28")
 *   <dfn for="user agent" export>full version</dfn> (for example: "72.0.3245.12", "3.14159", or "297.70E04154A")
-*   <dfn for="user agent" export>platform brand and version</dfn> (for example: "Windows NT 6.0", "iOS 15", or "AmazingOS 17G")
+*   <dfn for="user agent" export>platform brand</dfn> (for example: "Windows", "iOS", or "AmazingOS")
+*   <dfn for="user agent" export>platform version</dfn> (for example: "NT 6.0", "15", or "17G")
 *   <dfn for="user agent" export>platform architecture</dfn> (for example: "ARM64", or "ia32")
 *   <dfn for="user agent" export>model</dfn> (for example: "", or "Pixel 2 XL")
 *   <dfn for="user agent" export>mobileness</dfn> (for example: ?0 or ?1)
@@ -219,8 +220,7 @@ The 'Sec-CH-UA-Platform' Header Field {#sec-ch-platform}
 
 The <dfn http-header>`Sec-CH-UA-Platform`</dfn> request header field gives a server information about
 the platform on which a given user agent is executing. It is a [=Structured Header=] whose value
-MUST be a [=structured header/string=] [[I-D.ietf-httpbis-header-structure]]. Its value MAY include a
-"v" parameter, indicating the platform's version.
+MUST be a [=structured header/string=] [[I-D.ietf-httpbis-header-structure]].
 
 The header's ABNF is:
 
@@ -228,7 +228,19 @@ The header's ABNF is:
   Sec-CH-UA-Platform = sh-string
 ```
 
-ISSUE: Add processing model here that creates the header using SH serialization.
+The 'Sec-CH-UA-Platform-Version' Header Field {#sec-ch-platform-version}
+----------------------------------
+
+The <dfn http-header>`Sec-CH-UA-Platform-Version`</dfn> request header field gives a server
+information about the platform version on which a given user agent is executing. It is a
+[=Structured Header=] whose value MUST be a [=structured header/string=]
+[[I-D.ietf-httpbis-header-structure]].
+
+The header's ABNF is:
+
+``` abnf
+  Sec-CH-UA-Platform-Version = sh-string
+```
 
 The 'Sec-CH-UA' Header Field {#sec-ch-ua}
 ----------------------------
@@ -313,7 +325,8 @@ dictionary NavigatorUABrandVersionDict {
 interface NavigatorUAData {
   readonly attribute FrozenArray&lt;NavigatorUABrandVersionDict&gt; brand;
   readonly attribute boolean mobile;
-  Promise&lt;NavigatorUABrandVersionDict&gt; getPlatform();
+  Promise&lt;DOMString&gt; getPlatform();
+  Promise&lt;SOMString&gt; getPlatformVersion();
   Promise&lt;DOMString&gt; getArchitecture();
   Promise&lt;DOMString&gt; getModel();
 };
@@ -338,7 +351,9 @@ Processing model {#processing}
         :   {{NavigatorUAData/brand}}
         ::  The user agent's [=user agent/brand=].
         :   {{NavigatorUAData/getPlatform}}
-        ::  The user agent's [=user agent/platform brand and version=].
+        ::  The user agent's [=user agent/platform brand=].
+        :   {{NavigatorUAData/getPlatformVersion}}
+        ::  The user agent's [=user agent/platform version=].
         :   {{NavigatorUAData/getArchitecture}}
         ::  The user agent's [=user agent/platform architecture=].
         :   {{NavigatorUAData/getModel}}
@@ -444,9 +459,9 @@ in specs.
 IANA Considerations {#iana}
 ===================
 
-This document intends to define the `Sec-CH-UA-Arch`, `Sec-CH-UA-Model`, `Sec-CH-UA-Platform`, and
-`Sec-CH-UA` HTTP request header fields, and register them in the permanent message header
-field registry ([[RFC3864]]).
+This document intends to define the `Sec-CH-UA-Arch`, `Sec-CH-UA-Model`, `Sec-CH-UA-Platform`,
+`Sec-CH-UA-Platform-Version`, `Sec-CH-UA-Mobile` and `Sec-CH-UA` HTTP request header fields, and
+register them in the permanent message header field registry ([[RFC3864]]).
 
 It also intends to deprecate the `User-Agent` header field.
 
@@ -491,6 +506,24 @@ Specification document:
 
 Header field name:
 : Sec-CH-UA-Platform
+
+Applicable protocol:
+: http
+
+Status:
+: standard
+
+Author/Change controller:
+: IETF
+
+Specification document:
+: this specification ([[#sec-ch-platform]])
+
+'Sec-CH-UA-Platform-Version' Header Field {#iana-platform-version}
+------------------------------
+
+Header field name:
+: Sec-CH-UA-Platform-Version
 
 Applicable protocol:
 : http

--- a/index.bs
+++ b/index.bs
@@ -21,6 +21,7 @@ Boilerplate: omit conformance, omit feedback-header
 <pre class="link-defaults">
 spec:fetch; type:dfn; for:/; text:request
 spec:webidl; type:dfn; text:resolve
+spec:infra; type:dfn; text:user agent
 </pre>
 <pre class="anchors">
 urlPrefix: https://tools.ietf.org/html/draft-ietf-httpbis-header-structure; spec: I-D.ietf-httpbis-header-structure
@@ -168,8 +169,8 @@ User Agent Hints {#http-ua-hints}
 ================
 
 The following sections define a number of HTTP request header fields that expose detail about a
-given user agent, which servers can opt-into receiving via the Client Hints infrastructure defined
-in [[I-D.ietf-httpbis-client-hints]]. The definitions below assume that each user agent has defined
+given [=user agent=], which servers can opt-into receiving via the Client Hints infrastructure defined
+in [[I-D.ietf-httpbis-client-hints]]. The definitions below assume that each [=user agent=] has defined
 a number of properties for itself:
 
 *   <dfn for="user agent" export>brand</dfn> (for example: "cURL", "Edge", "The World's Best Web Browser")
@@ -181,15 +182,15 @@ a number of properties for itself:
 *   <dfn for="user agent" export>model</dfn> (for example: "", or "Pixel 2 XL")
 *   <dfn for="user agent" export>mobileness</dfn> (for example: ?0 or ?1)
 
-User agents SHOULD keep these strings short and to the point, but servers MUST accept arbitrary
-values for each, as they are all values constructed at the user agent's whim.
+[=User agents=] SHOULD keep these strings short and to the point, but servers MUST accept arbitrary
+values for each, as they are all values constructed at the [=user agent=]'s whim.
 
 
 The 'Sec-CH-UA-Arch' Header Field {#sec-ch-arch}
 ------------------------------
 
 The <dfn http-header>`Sec-CH-UA-Arch`</dfn> request header field gives a server information about
-the architecture of the platform on which a given user agent is executing. It is a
+the architecture of the platform on which a given [=user agent=] is executing. It is a
 [=Structured Header=] whose value MUST be a [=structured header/string=]
 [[I-D.ietf-httpbis-header-structure]].
 
@@ -204,7 +205,7 @@ The 'Sec-CH-UA-Model' Header Field {#sec-ch-model}
 -------------------------------
 
 The <dfn http-header>`Sec-CH-UA-Model`</dfn> request header field gives a server information about
-the device on which a given user agent is executing. It is a [=Structured Header=] whose value MUST
+the device on which a given [=user agent=] is executing. It is a [=Structured Header=] whose value MUST
 be a [=structured header/string=] [[I-D.ietf-httpbis-header-structure]].
 
 The header's ABNF is:
@@ -220,7 +221,7 @@ The 'Sec-CH-UA-Platform' Header Field {#sec-ch-platform}
 ----------------------------------
 
 The <dfn http-header>`Sec-CH-UA-Platform`</dfn> request header field gives a server information about
-the platform on which a given user agent is executing. It is a [=Structured Header=] whose value
+the platform on which a given [=user agent=] is executing. It is a [=Structured Header=] whose value
 MUST be a [=structured header/string=] [[I-D.ietf-httpbis-header-structure]].
 
 The header's ABNF is:
@@ -233,7 +234,7 @@ The 'Sec-CH-UA-Platform-Version' Header Field {#sec-ch-platform-version}
 ----------------------------------
 
 The <dfn http-header>`Sec-CH-UA-Platform-Version`</dfn> request header field gives a server
-information about the platform version on which a given user agent is executing. It is a
+information about the platform version on which a given [=user agent=] is executing. It is a
 [=Structured Header=] whose value MUST be a [=structured header/string=]
 [[I-D.ietf-httpbis-header-structure]].
 
@@ -247,10 +248,10 @@ The 'Sec-CH-UA' Header Field {#sec-ch-ua}
 ----------------------------
 
 The <dfn http-header>`Sec-CH-UA`</dfn> request header field gives a server information about a
-user agent's branding and version. It is a [=Structured Header=] whose value MUST be a
+[=user agent=]'s branding and version. It is a [=Structured Header=] whose value MUST be a
 [=structured header/list=] [[I-D.ietf-httpbis-header-structure]]. The list's items MUST be
 [=structured header/string=]. The value of each item SHOULD include a "v" parameter, indicating the
-user agent's version.
+[=user agent=]'s version.
 
 The header's ABNF is:
 
@@ -260,26 +261,26 @@ The header's ABNF is:
 
 Unlike most Client Hints, the `Sec-CH-UA` header will be sent with all requests, whether or not the
 server opted-into receiving the header via an `Accept-CH` header. Prior to an opt-in, however, it
-will include only the user agent's branding information, and the significant version number (both of which
+will include only the [=user agent=]'s branding information, and the significant version number (both of which
 are fairly clearly sniffable by "examining the structure of other headers and by testing for the
 availability and semantics of the features introduced or modified between releases of a particular
 browser" [[Janc2014]]).
 
 To <dfn abstract-op local-lt="set-ua">return the `Sec-CH-UA` value for a request</dfn>, given a
 <a href="https://wicg.github.io/client-hints-infrastructure/#environment-settings-object-client-hints-set">client hints set</a> (|set|),
-user agents MUST:
+[=user agents=] MUST:
 
 1.  Let |value| be a [=Structured Header=] object whose value is a [=structured header/list=].
 
-2.  Let |version| be the user agent's [=user agent/full version=] if |set|
-    [=list/contains=] `UA`, and the user agent's [=user agent/significant version=] otherwise.
+2.  Let |version| be the [=user agent=]'s [=user agent/full version=] if |set|
+    [=list/contains=] `UA`, and the [=user agent=]'s [=user agent/significant version=] otherwise.
 
-3.  Let |ua| be a string whose value is the [=string/concatenation=] of the user agent's
+3.  Let |ua| be a string whose value is the [=string/concatenation=] of the [=user agent=]'s
     [=user agent/brand=], the string ";v=", and |version|.
 
 4.  [=list/Append=] |ua| to |value|.
 
-5.  The user agent MAY execute the following steps:
+5.  The [=user agent=] MAY execute the following steps:
 
     1.  [=list/Append=] additional items to |value| containing arbitrary brand and version
         combinations.
@@ -298,7 +299,7 @@ The 'Sec-CH-UA-Mobile' Header Field {#sec-ch-mobile}
 --------------------------------
 
 The <dfn http-header>`Sec-CH-UA-Mobile`</dfn> request header field gives a server information about
-whether or not a user agent prefers a "mobile" user experience. It is a [=Structured Header=]
+whether or not a [=user agent=] prefers a "mobile" user experience. It is a [=Structured Header=]
 whose value MUST be a [=structured header/boolean=] [[I-D.ietf-httpbis-header-structure]].
 
 The header's ABNF is:
@@ -354,10 +355,10 @@ Every {{WindowOrWorkerGlobalScope}} object has an associated <dfn for="WindowOrW
 
 <h3 id="create-ua-list-section">Create a UA list</h3>
 
-When asked to run the <dfn>create UA list</dfn> algorithm, the user agent MUST run the following steps:
+When asked to run the <dfn>create UA list</dfn> algorithm, the [=user agent=] MUST run the following steps:
 1. Let |list| be a [=/list=].
 
-2. Collect pairs of [=user agent/brand=] and [=user agent/significant version=] which represent the user agent,
+2. Collect pairs of [=user agent/brand=] and [=user agent/significant version=] which represent the [=user agent=],
     its equivalence class and/or its rendering engine.
 
 3. For each pair:
@@ -367,7 +368,7 @@ When asked to run the <dfn>create UA list</dfn> algorithm, the user agent MUST r
 
     2. Append |dict| to |list|.
 
-4.  The user agent MAY execute the following steps:
+4.  The [=user agent=] MAY execute the following steps:
 
     1.  [=list/Append=] additional items to |list| containing {{NavigatorUABrandVersion}} objects,
         initialized with arbitrary {{NavigatorUABrandVersion/brand}} and {{NavigatorUABrandVersion/version}} combinations.
@@ -382,7 +383,7 @@ When asked to run the <dfn>create UA list</dfn> algorithm, the user agent MUST r
 
 On getting, the {{NavigatorUAData/uaList}} attribute MUST return [=this=]'s [=relevant global object=]'s [=WindowOrWorkerGlobalScope/UA frozen array=].
 
-On getting, the {{NavigatorUAData/mobile}} attribute must return the user agent's [=user agent/mobileness=].
+On getting, the {{NavigatorUAData/mobile}} attribute must return the [=user agent=]'s [=user agent/mobileness=].
 
 <h3 id="getHighEntropyValues"><code>getHighEntropyValues</code> method</h3>
 
@@ -394,13 +395,13 @@ The <dfn method for="NavigatorUA"><code>getHighEntropyValues(|hints|)</code></df
 
     1. Let |uaData| be a new {{UADataValues}}.
 
-    2. If |hints| [=contains=] "platform", set |uaData|["{{UADataValues/platform}}"] to the user agent's [=user agent/platform brand=].
+    2. If |hints| [=contains=] "platform", set |uaData|["{{UADataValues/platform}}"] to the [=user agent=]'s [=user agent/platform brand=].
 
-    3. If |hints| [=contains=] "platformVersion", set |uaData|["{{UADataValues/platformVersion}}"] to the user agent's [=user agent/platform version=].
+    3. If |hints| [=contains=] "platformVersion", set |uaData|["{{UADataValues/platformVersion}}"] to the [=user agent=]'s [=user agent/platform version=].
 
-    4. If |hints| [=contains=] "architecture", set |uaData|["{{UADataValues/architecture}}"] to the user agent's [=user agent/platform architecture=].
+    4. If |hints| [=contains=] "architecture", set |uaData|["{{UADataValues/architecture}}"] to the [=user agent=]'s [=user agent/platform architecture=].
 
-    5. If |hints| [=contains=] "model", set |uaData|["{{UADataValues/model}}"] to the user agent's [=user agent/model=].
+    5. If |hints| [=contains=] "model", set |uaData|["{{UADataValues/model}}"] to the [=user agent=]'s [=user agent/model=].
 
     6. [=Queue a task=] to [=resolve=] |p| with |uaData|.
 
@@ -415,14 +416,14 @@ Secure Transport {#secure-transport}
 ----------------
 
 Client Hints will not be delivered to non-secure endpoints (see the secure transport requirements in
-Section 2.2.1 of [[I-D.ietf-httpbis-client-hints]]). This means that user agent information will not
+Section 2.2.1 of [[I-D.ietf-httpbis-client-hints]]). This means that [=user agent=] information will not
 be leaked over plaintext channels, reducing the opportunity for network attackers to build a profile
 of a given agent's behavior over time.
 
 Delegation {#delegation}
 ----------
 
-Client Hints will be delegated from top-level pages via Feature Policy. This reduces the likelihood that user agent
+Client Hints will be delegated from top-level pages via Feature Policy. This reduces the likelihood that [=user agent=]
 information will be delivered along with subresource requests, which reduces the potential for
 passive fingerprinting.
 
@@ -432,9 +433,9 @@ Access Restrictions {#access}
 -------------------
 
 The information in the Client Hints defined above reveals quite a bit of information about the user
-agent and the platform/device upon which it runs. User agents ought to exercise judgement before
+agent and the platform/device upon which it runs. [=User agents=] ought to exercise judgement before
 granting access to this information, and MAY impose restrictions above and beyond the secure
-transport and delegation requirements noted above. For instance, user agents could choose to reveal
+transport and delegation requirements noted above. For instance, [=user agents=] could choose to reveal
 [=user agent/platform architecture=] only on requests it intends to download, giving the server the
 opportunity to serve the right binary. Likewise, they could offer users control over the values
 revealed to servers, or gate access on explicit user interaction via a permission prompt or via a
@@ -446,12 +447,12 @@ Implementation Considerations {#impl-considerations}
 The 'User-Agent' Header {#user-agent}
 -----------------------
 
-User agents SHOULD deprecate the `User-Agent` header in favor of the Client Hints model described in
+[=User agents=] SHOULD deprecate the `User-Agent` header in favor of the Client Hints model described in
 this document. The header, however, is likely to be impossible to remove entirely in the near-term,
 as existing sites' content negotiation code will continue to require its presence (see
 [[Rossi2015]] for a recent example of a new browser's struggles in this area).
 
-One approach which might be advisable could be for each user agent to lock the value of its
+One approach which might be advisable could be for each [=user agent=] to lock the value of its
 `User-Agent` header, ensuring backwards compatibility by maintaining the crufty declarations of
 "like Gecko" and "AppleWebKit/537.36" on into eternity. This can ratchet over time, first freezing
 the version number, then shifting platform and model information to something reasonably generic in
@@ -460,7 +461,7 @@ order to reduce the fingerprint the header provides.
 GREASE-like UA Strings {#grease}
 ----------------------
 
-History has shown us that there are real incentives for user agents to lie
+History has shown us that there are real incentives for [=user agents=] to lie
 about their branding in order to thread the needle of sites' sniffing scripts,
 and prevent their users from being blocked by UA-based allow/block lists.
 
@@ -470,7 +471,7 @@ protocol introduced the notion of <abbr title="Generate Random Extensions And
 Sustain Extensibility">GREASE</abbr> [[I-D.ietf-tls-grease]]. We could borrow
 from that concept to tackle this problem.
 
-User agents SHOULD model `UA` as a set, rather than a single entry. They then
+[=User agents=] SHOULD model `UA` as a set, rather than a single entry. They then
 could encourage standardized processing of the `UA` string, by randomly
 including additional, intentionally incorrect, comma-separated entries with
 arbitrary ordering. That would reduce the chance that we ossify on a few


### PR DESCRIPTION
Closes #11 and #45


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: write EPROTO 140222018242432:error:1407742E:SSL routines:SSL23_GET_SERVER_HELLO:tlsv1 alert protocol version:../deps/openssl/openssl/ssl/s23_clnt.c:772:
 :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 16, 2020, 9:20 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [HTML Diff Service](http://services.w3.org/htmldiff) - The HTML Diff Service is used to create HTML diffs of the spec changes suggested in a pull request.

:link: [Related URL](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2FWICG%2Fua-client-hints%2Fpull%2F79%2Fa55cb91.html&doc2=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fyoavweiss%2Fua-client-hints%2Fpull%2F79.html)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20WICG/ua-client-hints%2379.)._
</details>
