### PR TITLE
Note explaining why high-entropy bits are behind a Promise

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -344,6 +344,8 @@ Navigator includes NavigatorUA;
 
 </pre>
 
+Note: The high-entropy portions of the user agent information are retrieved through a {{Promise}}, in order to give [=user agents=] the opportunity to gate their exposure behind potentially time-consuming checks (e.g. by asking the user for their permission).
+
 Processing model {#processing}
 --------------
 


### PR DESCRIPTION
Closes #28


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yoavweiss/ua-client-hints/pull/82.html" title="Last updated on Mar 9, 2020, 4:21 PM UTC (12ede30)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/ua-client-hints/82/55f3147...yoavweiss:12ede30.html" title="Last updated on Mar 9, 2020, 4:21 PM UTC (12ede30)">Diff</a>