### PR TITLE
Simple typo fix

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -542,7 +542,7 @@ semi-colons to those values. The purpose of this is to make non-compliant server
 immediately aware that their parsing code is inadequate.
 
 The value order in [=user agent/brands=] MUST change over time, the prevent receivers of the header
-from relying on certain values beeing in certain locations in the string.
+from relying on certain values being in certain locations in the string.
 
 When choosing GREASE strategies, [=user agents=] SHOULD keep caching variance in mind and minimize
 variance among identical [=user agent=] versions.


### PR DESCRIPTION
Not sure if minor changes are accepted, but noticed this typo when reading through.

Thanks.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ArkUmbra/ua-client-hints/pull/121.html" title="Last updated on Aug 12, 2020, 12:27 AM UTC (a36960f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/ua-client-hints/121/4c30db6...ArkUmbra:a36960f.html" title="Last updated on Aug 12, 2020, 12:27 AM UTC (a36960f)">Diff</a>