### PR TITLE
Issue #151 - Make it possible to reject a promise from getHighEntropyValues

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -441,7 +441,7 @@ When asked to run the <dfn>create brands</dfn> algorithm, the [=user agent=] MUS
 
     Note: One approach to minimize caching variance when generating these random components could be to
     determine them at build time, and keep them identical throughout the lifetime of the [=user agent=]'s significant
-    version. 
+    version.
 
     Note: See [[#grease]] for more details on when and why these randomization steps might be appropriate.
 
@@ -459,7 +459,11 @@ The <dfn method for="NavigatorUA"><code>getHighEntropyValues(|hints|)</code></df
 
 1. Let |p| be a [=a new promise=] created in the [=current realm=].
 
-2.  Run the following steps [=in parallel=]:
+2. If the [=user agent=] decides one or more values in |hints| should not be returned, then [=reject=] and return |p| with a "{{NotAllowedError}}".
+
+ISSUE(wicg/ua-client-hints): We can improve upon when and why a UA decides to refuse a hint once [Issue #151](https://github.com/WICG/ua-client-hints/issues/151) is resolved.
+
+3. Otherwise, run the following steps [=in parallel=]:
 
     1. Let |uaData| be a new {{UADataValues}}.
 
@@ -475,7 +479,7 @@ The <dfn method for="NavigatorUA"><code>getHighEntropyValues(|hints|)</code></df
 
     7. [=Queue a task=] on the [=permission task source=] to [=resolve=] |p| with |uaData|.
 
-3.  Return |p|.
+4.  Return |p|.
 
 Security and Privacy Considerations {#security-privacy}
 ===================================


### PR DESCRIPTION
This partially addresses #151 by allowing UAs to reject the promise created from getHighEntropyValues. Once we have consensus on the rest, we can remove the issue and clarify what it means to "decide".

PTAL @amtunlimited

cc @othermaciej


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/miketaylr/ua-client-hints/pull/163.html" title="Last updated on Dec 16, 2020, 5:19 PM UTC (11548b9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/ua-client-hints/163/8ee4664...miketaylr:11548b9.html" title="Last updated on Dec 16, 2020, 5:19 PM UTC (11548b9)">Diff</a>