### PR TITLE
Amend the chapter on delegation to make this simpler and respect trust signal already provided.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -491,11 +491,16 @@ of a given agent's behavior over time.
 Delegation {#delegation}
 ----------
 
-Client Hints will be delegated from top-level pages via Feature Policy. This reduces the likelihood that [=user agent=]
-information will be delivered along with subresource requests, which reduces the potential for
-passive fingerprinting.
+All requests initiated by the user agent (aka as third party) will contain the
+same Client Hint headers as those requested by the origin (also know as first 
+party). For example if the a request to https://example.com included the 
+Sec-CH-UA-Full-Version HTTP header field then Sec-CH-UA-Full-Version would also
+be sent in all requests initiated by the response to the original request.
 
-That delegation is defined as part of [=append client hints to request=].
+An origin can trust it's supply chain partners. The act of including
+instructions to communicate with a partner expresses that trust choice. To 
+restrict, otherwise interfere, or add complexity such as to make the web 
+developers role more difficult must be avoided.
 
 Access Restrictions {#access}
 -------------------


### PR DESCRIPTION
Web site operators should be free to choose their suppliers without undue interference or complexity. This modification respects that right and simplifies the proposal. Relates to issue [152](https://github.com/WICG/ua-client-hints/issues/152) and [155](https://github.com/WICG/ua-client-hints/issues/155).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jwrosewell/ua-client-hints/pull/165.html" title="Last updated on Mar 5, 2021, 9:43 PM UTC (4062560)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/ua-client-hints/165/0edcf9d...jwrosewell:4062560.html" title="Last updated on Mar 5, 2021, 9:43 PM UTC (4062560)">Diff</a>