### PR TITLE
Removed duplication associated with secure transports

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -480,14 +480,6 @@ The <dfn method for="NavigatorUA"><code>getHighEntropyValues(|hints|)</code></df
 Security and Privacy Considerations {#security-privacy}
 ===================================
 
-Secure Transport {#secure-transport}
-----------------
-
-Client Hints will not be delivered to non-secure endpoints (see the secure transport requirements in
-Section 2.2.1 of [[I-D.ietf-httpbis-client-hints]]). This means that [=user agent=] information will not
-be leaked over plaintext channels, reducing the opportunity for network attackers to build a profile
-of a given agent's behavior over time.
-
 Delegation {#delegation}
 ----------
 


### PR DESCRIPTION
This is already covered in the dependent specification concerning client hints.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jwrosewell/ua-client-hints/pull/166.html" title="Last updated on Dec 18, 2020, 5:17 PM UTC (cca3a5e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/ua-client-hints/166/0edcf9d...jwrosewell:cca3a5e.html" title="Last updated on Dec 18, 2020, 5:17 PM UTC (cca3a5e)">Diff</a>