### PR TITLE
Added issue related to the definition of high or low entropy.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -314,6 +314,12 @@ and the significant version number (both of which are fairly clearly sniffable b
 structure of other headers and by testing for the availability and semantics of the features
 introduced or modified between releases of a particular browser" [[Janc2014]]).
 
+ISSUE: What is the policy for classifying some Client Hints as being sent by default? Either all Client 
+Hints should be sent on every request, or no Client Hints sent on first request. If the rationale for
+the specification is to limit entropy then sending a value will increase entropy for minority browser 
+vendors, whilst decrease it for dominate browser vendors. If the rationale is to address historic 
+issues with the `User-Agent` field value construction this could be better addressed via a simpler 
+specification to introduce a more modern convention for the field.
 
 To <dfn abstract-op local-lt="set-ua">return the `Sec-CH-UA` value for a request</dfn>, [=user agents=] MUST:
 


### PR DESCRIPTION
Need definition for implementors concerning how classifications are determined. Guidance is needed to ensure information asymmetries do not exist between user agent vendors and the wider web eco system.

Relates to issue [134](https://github.com/WICG/ua-client-hints/issues/134) and [131](https://github.com/WICG/ua-client-hints/issues/131).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jwrosewell/ua-client-hints/pull/173.html" title="Last updated on Dec 18, 2020, 5:35 PM UTC (d27673e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/ua-client-hints/173/0edcf9d...jwrosewell:d27673e.html" title="Last updated on Dec 18, 2020, 5:35 PM UTC (d27673e)">Diff</a>