### PR TITLE
Fixes #198 - Update references to newly minted RFCs 8941 and 8942

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -26,13 +26,13 @@ spec:infra; type:dfn; text:user agent
 spec:infra; type:dfn; for:/; text:list
 </pre>
 <pre class="anchors">
-urlPrefix: https://tools.ietf.org/html/draft-ietf-httpbis-header-structure; spec: I-D.ietf-httpbis-header-structure
+urlPrefix: https://tools.ietf.org/html/rfc8941; spec: rfc8941
     type: dfn
         text: structured header; url: #
     for: structured header
         type: dfn
-            text: token; url: #section-3.3.6
-            text: boolean; url: #section-3.3.4
+            text: token; url: #section-3.3.4
+            text: boolean; url: #section-3.3.6
             text: string; url: #section-3.3.3
             text: list; url: #section-3.1
             text: serializing a list; url: #section-4.1.1
@@ -55,20 +55,6 @@ urlPrefix: https://tc39.es/ecma262/
     "href": "https://engineering.fb.com/android/year-class-a-classification-system-for-android/",
     "title": "Year class: A classification system for Android",
     "authors": [ "Chris Marra", "Daniel Weaver" ]
-  },
-  "I-D.ietf-httpbis-client-hints": {
-    "href": "https://tools.ietf.org/html/draft-ietf-httpbis-client-hints",
-    "title": "HTTP Client Hints",
-    "authors": [ "Ilya Grigorik", "Yoav Weiss" ],
-    "status": "ID",
-    "publisher": "IETF"
-  },
-  "I-D.ietf-httpbis-header-structure": {
-    "authors": [ "Mark Nottingham", "Poul-Henning Kamp" ],
-    "href": "https://tools.ietf.org/html/draft-ietf-httpbis-header-structure",
-    "title": "Structured Headers for HTTP",
-    "status": "ID",
-    "publisher": "IETF"
   },
   "I-D.ietf-tls-grease": {
     "href": "https://tools.ietf.org/html/draft-ietf-tls-grease",
@@ -144,7 +130,7 @@ developers that have stymied historical approaches:
 This document proposes a mechanism which might allow user agents to be a bit more aggressive about
 removing entropy from the `User-Agent` string generally by giving servers that really need some
 specific details about the client the ability to opt-into receiving them. It introduces four new
-Client Hints ([[I-D.ietf-httpbis-client-hints]]) that can provide the client's branding and version
+Client Hints ([[!RFC8942]]) that can provide the client's branding and version
 information, the underlying operating system's branding and major version, as well as details about
 the underlying device. Rather than broadcasting this data to everyone, all the time, user agents can
 make reasonable decisions about how to respond to given sites' requests for more granular data,
@@ -162,7 +148,7 @@ user agent sends the following header along with the HTTP request:
 
 The server is interested in rendering content consistent with the user's underlying platform, and
 asks for a little more information by sending an `Accept-CH` header (Section 2.2.1 of
-[[I-D.ietf-httpbis-client-hints]]) along with the initial response:
+[[!RFC8942]]) along with the initial response:
 
 ``` http
   Accept-CH: Sec-CH-UA-Full-Version, Sec-CH-UA-Platform
@@ -183,19 +169,19 @@ Infrastructure {#infrastructure}
 This specification depends on Client Hints Infrastructure, HTTP Client Hints, and the Infra
 Standard.
 [[!CLIENT-HINTS-INFRASTRUCTURE]]
-[[!I-D.ietf-httpbis-client-hints]]
+[[!RFC8942]]
 [[!INFRA]]
 
 Some of the terms used in this specification are defined in <cite>Structured Field Values for
 HTTP</cite>.
-[[!I-D.ietf-httpbis-header-structure]]
+[[!RFC8941]]
 
 User Agent Hints {#http-ua-hints}
 ================
 
 The following sections define a number of HTTP request header fields that expose detail about a
 given [=user agent=], which servers can opt-into receiving via the Client Hints infrastructure
-defined in [[I-D.ietf-httpbis-client-hints]]. The definitions below assume that each [=user agent=]
+defined in [[!RFC8942]]. The definitions below assume that each [=user agent=]
 has defined a number of properties for itself:
 
 *   <dfn for="user agent" export>brand</dfn> - The [=user agent=]'s commercial name (for example:
@@ -251,7 +237,7 @@ The 'Sec-CH-UA-Arch' Header Field {#sec-ch-ua-arch}
 The <dfn http-header>`Sec-CH-UA-Arch`</dfn> request header field gives a server information about
 the architecture of the platform on which a given [=user agent=] is executing. It is a
 [=Structured Header=] whose value MUST be a [=structured header/string=]
-[[I-D.ietf-httpbis-header-structure]].
+[[!RFC8941]].
 
 The header's ABNF is:
 
@@ -265,7 +251,7 @@ The 'Sec-CH-UA-Model' Header Field {#sec-ch-ua-model}
 
 The <dfn http-header>`Sec-CH-UA-Model`</dfn> request header field gives a server information about
 the device on which a given [=user agent=] is executing. It is a [=Structured Header=] whose value MUST
-be a [=structured header/string=] [[I-D.ietf-httpbis-header-structure]].
+be a [=structured header/string=] [[!RFC8941]].
 
 The header's ABNF is:
 
@@ -281,7 +267,7 @@ The 'Sec-CH-UA-Platform' Header Field {#sec-ch-ua-platform}
 
 The <dfn http-header>`Sec-CH-UA-Platform`</dfn> request header field gives a server information about the platform on
 which a given [=user agent=] is executing. It is a [=Structured Header=] whose value MUST be a
-[=structured header/string=] [[I-D.ietf-httpbis-header-structure]]. Its value SHOULD match one of the following common
+[=structured header/string=] [[!RFC8941]]. Its value SHOULD match one of the following common
 platform values: "Android", "Chrome OS", "iOS", "Linux", "macOS", "Windows", or "Unknown".
 
 The header's ABNF is:
@@ -296,7 +282,7 @@ The 'Sec-CH-UA-Platform-Version' Header Field {#sec-ch-ua-platform-version}
 The <dfn http-header>`Sec-CH-UA-Platform-Version`</dfn> request header field gives a server
 information about the platform version on which a given [=user agent=] is executing. It is a
 [=Structured Header=] whose value MUST be a [=structured header/string=]
-[[I-D.ietf-httpbis-header-structure]].
+[[!RFC8941]].
 
 The header's ABNF is:
 
@@ -309,7 +295,7 @@ The 'Sec-CH-UA' Header Field {#sec-ch-ua}
 
 The <dfn http-header>`Sec-CH-UA`</dfn> request header field gives a server information about a
 [=user agent=]'s branding and version. It is a [=Structured Header=] whose value MUST be a
-[=structured header/list=] [[I-D.ietf-httpbis-header-structure]]. The list's items MUST be
+[=structured header/list=] [[!RFC8941]]. The list's items MUST be
 [=structured header/string=]. The value of each item SHOULD include a "v" parameter, indicating the
 [=user agent=]'s version.
 
@@ -352,7 +338,7 @@ The 'Sec-CH-UA-Full-Version' Header Field {#sec-ch-ua-full-version}
 
 The <dfn http-header>`Sec-CH-UA-Full-Version`</dfn> request header field gives a server information
 about the user agent's [=user agent/full version=]. It is a [=Structured Header=]
-whose value MUST be a [=structured header/string=] [[I-D.ietf-httpbis-header-structure]].
+whose value MUST be a [=structured header/string=] [[!RFC8941]].
 
 The header's ABNF is:
 
@@ -365,7 +351,7 @@ The 'Sec-CH-UA-Mobile' Header Field {#sec-ch-ua-mobile}
 
 The <dfn http-header>`Sec-CH-UA-Mobile`</dfn> request header field gives a server information about
 whether or not a [=user agent=] prefers a "mobile" user experience. It is a [=Structured Header=]
-whose value MUST be a [=structured header/boolean=] [[I-D.ietf-httpbis-header-structure]].
+whose value MUST be a [=structured header/boolean=] [[!RFC8941]].
 
 The header's ABNF is:
 
@@ -539,7 +525,7 @@ Secure Transport {#secure-transport}
 ----------------
 
 Client Hints will not be delivered to non-secure endpoints (see the secure transport requirements in
-Section 2.2.1 of [[I-D.ietf-httpbis-client-hints]]). This means that [=user agent=] information will not
+Section 2.2.1 of [[!RFC8941]]). This means that [=user agent=] information will not
 be leaked over plaintext channels, reducing the opportunity for network attackers to build a profile
 of a given agent's behavior over time.
 


### PR DESCRIPTION
Structured Field Values for HTTP and HTTP Client Hints are now RFCs,
8941 and 8942 respectively.

PTAL @yoavweiss (also, congrats on moving HTTP Client Hints to the RFC stage!)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/miketaylr/ua-client-hints/pull/199.html" title="Last updated on Feb 9, 2021, 7:48 PM UTC (7ea41f8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/ua-client-hints/199/17d492f...miketaylr:7ea41f8.html" title="Last updated on Feb 9, 2021, 7:48 PM UTC (7ea41f8)">Diff</a>