### PR TITLE
fix: De-DefinitionList the headers

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -649,146 +649,106 @@ It also intends to deprecate usage of the `User-Agent` header field.
 'Sec-CH-UA-Arch' Header Field {#iana-arch}
 --------------------------
 
-Header field name:
-: Sec-CH-UA-Arch
+Header field name: Sec-CH-UA-Arch
 
-Applicable protocol:
-: http
+Applicable protocol: http
 
-Status:
-: standard
+Status: standard
 
-Author/Change controller:
-: IETF
+Author/Change controller: IETF
 
-Specification document:
-: this specification ([[#sec-ch-ua-arch]])
+Specification document: this specification ([[#sec-ch-ua-arch]])
 
 'Sec-CH-UA-Model' Header Field {#iana-model}
 ---------------------------
 
-Header field name:
-: Sec-CH-UA-Model
+Header field name: Sec-CH-UA-Model
 
-Applicable protocol:
-: http
+Applicable protocol: http
 
-Status:
-: standard
+Status: standard
 
-Author/Change controller:
-: IETF
+Author/Change controller: IETF
 
-Specification document:
-: this specification ([[#sec-ch-ua-model]])
+Specification document: this specification ([[#sec-ch-ua-model]])
 
 'Sec-CH-UA-Platform' Header Field {#iana-platform}
 ------------------------------
 
-Header field name:
-: Sec-CH-UA-Platform
+Header field name: Sec-CH-UA-Platform
 
-Applicable protocol:
-: http
+Applicable protocol: http
 
-Status:
-: standard
+Status: standard
 
-Author/Change controller:
-: IETF
+Author/Change controller: IETF
 
-Specification document:
-: this specification ([[#sec-ch-ua-platform]])
+Specification document: this specification ([[#sec-ch-ua-platform]])
 
 'Sec-CH-UA-Platform-Version' Header Field {#iana-platform-version}
 ------------------------------
 
-Header field name:
-: Sec-CH-UA-Platform-Version
+Header field name: Sec-CH-UA-Platform-Version
 
-Applicable protocol:
-: http
+Applicable protocol: http
 
-Status:
-: standard
+Status: standard
 
-Author/Change controller:
-: IETF
+Author/Change controller: IETF
 
-Specification document:
-: this specification ([[#sec-ch-ua-platform-version]])
+Specification document: this specification ([[#sec-ch-ua-platform-version]])
 
 'Sec-CH-UA' Header Field {#iana-ua}
 ------------------------
 
-Header field name:
-: Sec-CH-UA
+Header field name: Sec-CH-UA
 
-Applicable protocol:
-: http
+Applicable protocol: http
 
-Status:
-: standard
+Status: standard
 
-Author/Change controller:
-: IETF
+Author/Change controller: IETF
 
-Specification document:
-: this specification ([[#sec-ch-ua]])
+Specification document: this specification ([[#sec-ch-ua]])
 
 'Sec-CH-UA-Mobile' Header Field {#iana-mobile}
 ----------------------------
 
-Header field name:
-: Sec-CH-UA-Mobile
+Header field name: Sec-CH-UA-Mobile
 
-Applicable protocol:
-: http
+Applicable protocol: http
 
-Status:
-: standard
+Status: standard
 
-Author/Change controller:
-: IETF
+Author/Change controller: IETF
 
-Specification document:
-: this specification ([[#sec-ch-ua-mobile]])
+Specification document: this specification ([[#sec-ch-ua-mobile]])
 
 'Sec-CH-UA-Full-Version' Header Field {#iana-full-version}
 ----------------------------
 
-Header field name:
-: Sec-CH-UA-Full-Version
+Header field name: Sec-CH-UA-Full-Version
 
-Applicable protocol:
-: http
+Applicable protocol: http
 
-Status:
-: standard
+Status: standard
 
-Author/Change controller:
-: IETF
+Author/Change controller: IETF
 
-Specification document:
-: this specification ([[#sec-ch-ua-full-version]])
+Specification document: this specification ([[#sec-ch-ua-full-version]])
 
 'User-Agent' Header Field {#iana-user-agent}
 -------------------------
 
-Header field name:
-: User-Agent
+Header field name: User-Agent
 
-Applicable protocol:
-: http
+Applicable protocol: http
 
-Status:
-: deprecated
+Status: deprecated
 
-Author/Change controller:
-: IETF
+Author/Change controller: IETF
 
-Specification document:
-: this specification ([[#user-agent]]), and Section 5.5.3 of [[RFC7231]]
+Specification document: this specification ([[#user-agent]]), and Section 5.5.3 of [[RFC7231]]
 
 Acknowledgments {#ack}
 =============================


### PR DESCRIPTION
Bikeshed transforms the leading `:` into defintionlists with stub DTs, which get flagged by HTML validation


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nschonni/ua-client-hints/pull/202.html" title="Last updated on Feb 13, 2021, 9:40 PM UTC (5e85b99)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/ua-client-hints/202/61d6c21...nschonni:5e85b99.html" title="Last updated on Feb 13, 2021, 9:40 PM UTC (5e85b99)">Diff</a>