### PR TITLE
Fixes #213 - Make platform a default, low-entropy hint

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -246,7 +246,7 @@ the architecture of the platform on which a given [=user agent=] is executing. I
 The header's ABNF is:
 
 ~~~ abnf
-  Sec-CH-UA-Arch = sh-string
+  Sec-CH-UA-Arch = sf-string
 ~~~
 
 The 'Sec-CH-UA-Bitness' Header Field {#sec-ch-ua-bitness}
@@ -260,7 +260,7 @@ a [=Structured Header=] whose value MUST be a [=structured header/string=]
 The header's ABNF is:
 
 ~~~ abnf
-  Sec-CH-UA-Bitness = sh-string
+  Sec-CH-UA-Bitness = sf-string
 ~~~
 
 The 'Sec-CH-UA-Model' Header Field {#sec-ch-ua-model}
@@ -273,7 +273,7 @@ be a [=structured header/string=] [[!RFC8941]].
 The header's ABNF is:
 
 ``` abnf
-  Sec-CH-UA-Model = sh-string
+  Sec-CH-UA-Model = sf-string
 ```
 
 ISSUE(wicg/ua-client-hints): Perhaps `Sec-CH-UA-Mobile` is enough, and we don't need to expose the model?
@@ -290,7 +290,7 @@ platform values: "Android", "Chrome OS", "iOS", "Linux", "macOS", "Windows", or 
 The header's ABNF is:
 
 ``` abnf
-  Sec-CH-UA-Platform = sh-string
+  Sec-CH-UA-Platform = sf-string
 ```
 
 The 'Sec-CH-UA-Platform-Version' Header Field {#sec-ch-ua-platform-version}
@@ -304,7 +304,7 @@ information about the platform version on which a given [=user agent=] is execut
 The header's ABNF is:
 
 ``` abnf
-  Sec-CH-UA-Platform-Version = sh-string
+  Sec-CH-UA-Platform-Version = sf-string
 ```
 
 The 'Sec-CH-UA' Header Field {#sec-ch-ua}
@@ -319,7 +319,7 @@ The <dfn http-header>`Sec-CH-UA`</dfn> request header field gives a server infor
 The header's ABNF is:
 
 ``` abnf
-  Sec-CH-UA = sh-list
+  Sec-CH-UA = sf-list
 ```
 
 Note: Unlike most Client Hints, since it's included in the [=low entropy hint table=],
@@ -360,7 +360,7 @@ whose value MUST be a [=structured header/string=] [[!RFC8941]].
 The header's ABNF is:
 
 ``` abnf
-  Sec-CH-UA-Full-Version = sh-string
+  Sec-CH-UA-Full-Version = sf-string
 ```
 
 The 'Sec-CH-UA-Mobile' Header Field {#sec-ch-ua-mobile}
@@ -373,7 +373,7 @@ whose value MUST be a [=structured header/boolean=] [[!RFC8941]].
 The header's ABNF is:
 
 ``` abnf
-  Sec-CH-UA-Mobile = sh-boolean
+  Sec-CH-UA-Mobile = sf-boolean
 ```
 
 Note: Like `Sec-CH-UA` above, since it's included in the [=low entropy hint table=],

--- a/index.bs
+++ b/index.bs
@@ -383,8 +383,9 @@ To <dfn abstract-op local-lt="set-ua">return the `Sec-CH-UA` value for a request
 
 3. Return the output of running [=serializing a list=] with |list| as input.
 
-Note: These client hints can be evoked with the following set of [=Client hints tokens=]:
-`Sec-CH-UA-Arch`, `Sec-CH-UA-Model`, `Sec-CH-UA-Platform`, `Sec-CH-UA`, `Sec-CH-UA-Mobile`
+Note: These client hints can be evoked with the following set of [=client hints tokens=]:
+`Sec-CH-UA`, `Sec-CH-UA-Arch`, `Sec-CH-UA-Bitness`, `Sec-CH-UA-Full-Version`, `Sec-CH-UA-Mobile`,
+`Sec-CH-UA-Model`, `Sec-CH-UA-Platform`, `Sec-CH-UA-Platform-Version`
 
 
 Interface {#interface}

--- a/index.bs
+++ b/index.bs
@@ -146,28 +146,30 @@ in [[FINGERPRINTING-GUIDANCE]]).
 Examples {#examples}
 --------
 
-A user navigates to `https://example.com/` for the first time using the latest version of the "Examplary Browser". Their
-user agent sends the following header along with the HTTP request:
+A user navigates to `https://example.com/` for the first time using the latest version of the
+"Examplary Browser". Their user agent sends the following headers along with the HTTP request:
 
 ``` http
   Sec-CH-UA: "Examplary Browser"; v="73", ";Not?A.Brand"; v="27"
+  Sec-CH-UA-Mobile: ?0
+  Sec-CH-UA-Platform: "Windows"
 ```
 
-The server is interested in rendering content consistent with the user's underlying platform, and
-asks for a little more information by sending an `Accept-CH` header (Section 2.2.1 of
+The server is interested in rendering content consistent with the user's underlying platform version,
+and asks for a little more information by sending an `Accept-CH` header (Section 2.2.1 of
 [[!RFC8942]]) along with the initial response:
 
 ``` http
-  Accept-CH: Sec-CH-UA-Full-Version, Sec-CH-UA-Platform
+  Accept-CH: Sec-CH-UA-Platform-Version
 ```
 
-In response, the user agent includes more detailed version information, as well as information about
-the underlying platform in the next request:
+In response, the user agent includes the platform version information in the next request:
 
 ``` http
   Sec-CH-UA: "Examplary Browser"; v="73", ";Not?A.Brand"; v="27"
-  Sec-CH-UA-Full-Version: "73.3R8.2H.1"
+  Sec-CH-UA-Mobile: ?0
   Sec-CH-UA-Platform: "Windows"
+  Sec-CH-UA-Full-Version: "10.0.19042"
 ```
 
 Infrastructure {#infrastructure}

--- a/index.bs
+++ b/index.bs
@@ -317,10 +317,9 @@ The header's ABNF is:
 
 Note: Like `Sec-CH-UA` above, since it's included in the [=low entropy hint table=],
 the `Sec-CH-UA-Mobile` header will be sent by default, whether or not the server opted-into
-receiving the header via an `Accept-CH` header (although it can still be controlled by it's
-[=policy controlled client hints feature=].
-It is considered low enropy because it is a single bit of information directly controllable
-by the user.
+receiving the header via an `Accept-CH` header (although it can still be controlled by its
+[=policy controlled client hints feature=]). It is considered low entropy because it is a single
+bit of information directly controllable by the user.
 
 The 'Sec-CH-UA-Model' Header Field {#sec-ch-ua-model}
 -------------------------------
@@ -341,16 +340,22 @@ ISSUE(wicg/ua-client-hints): Perhaps `Sec-CH-UA-Mobile` is enough, and we don't 
 The 'Sec-CH-UA-Platform' Header Field {#sec-ch-ua-platform}
 ----------------------------------
 
-The <dfn http-header>`Sec-CH-UA-Platform`</dfn> request header field gives a server information about the platform on
-which a given [=user agent=] is executing. It is a [=Structured Header=] whose value MUST be a
-[=structured header/string=] [[!RFC8941]]. Its value SHOULD match one of the following common
-platform values: "Android", "Chrome OS", "iOS", "Linux", "macOS", "Windows", or "Unknown".
+The <dfn http-header>`Sec-CH-UA-Platform`</dfn> request header field gives a server information
+about the platform on which a given [=user agent=] is executing. It is a [=Structured Header=]
+whose value MUST be a [=structured header/string=] [[!RFC8941]]. Its value SHOULD match one of the
+following common platform values: "Android", "Chrome OS", "iOS", "Linux", "macOS", "Windows", or
+"Unknown".
 
 The header's ABNF is:
 
 ``` abnf
   Sec-CH-UA-Platform = sf-string
 ```
+
+Note: Like `Sec-CH-UA` above, since it's included in the [=low entropy hint table=], the
+`Sec-CH-UA-Platform` header will be sent by default, whether or not the server opted-into receiving
+the header via an `Accept-CH` header (although it can still be controlled by its
+[=policy controlled client hints feature=]).
 
 The 'Sec-CH-UA-Platform-Version' Header Field {#sec-ch-ua-platform-version}
 ----------------------------------
@@ -403,7 +408,6 @@ dictionary UADataValues {
   DOMString architecture;
   DOMString bitness;
   DOMString model;
-  DOMString platform;
   DOMString platformVersion;
   DOMString uaFullVersion;
 };
@@ -412,6 +416,7 @@ dictionary UADataValues {
 interface NavigatorUAData {
   readonly attribute FrozenArray&lt;NavigatorUABrandVersion&gt; brands;
   readonly attribute boolean mobile;
+  readonly attribute DOMString platform;
   Promise&lt;UADataValues&gt; getHighEntropyValues(sequence&lt;DOMString&gt; hints);
 };
 
@@ -511,6 +516,8 @@ On getting, the {{NavigatorUAData/brands}} attribute MUST return [=this=]'s [=re
 
 On getting, the {{NavigatorUAData/mobile}} attribute must return the [=user agent=]'s [=user agent/mobileness=].
 
+On getting, the {{NavigatorUAData/platform}} attribute must return the [=user agent=]'s [=user agent/platform brand=].
+
 <h4 id="getHighEntropyValues"><code>getHighEntropyValues</code> method</h4>
 
 The <dfn method for="NavigatorUA"><code>getHighEntropyValues(|hints|)</code></dfn> method MUST run these steps:
@@ -531,8 +538,6 @@ ISSUE(wicg/ua-client-hints): We can improve upon when and why a UA decides to re
         the [=user agent=]'s [=user agent/platform bitness=].
     1. If |hints| [=list/contains=] "model", set |uaData|["{{UADataValues/model}}"] to the
         [=user agent=]'s [=user agent/model=].
-    1. If |hints| [=list/contains=] "platform", set |uaData|["{{UADataValues/platform}}"] to the
-        [=user agent=]'s [=user agent/platform brand=].
     1. If |hints| [=list/contains=] "platformVersion", set |uaData|["{{UADataValues/platformVersion}}"]
         to the [=user agent=]'s [=user agent/platform version=].
     1. If |hints| [=list/contains=] "uaFullVersion", let |uaData|["{{UADataValues/uaFullVersion}}"]
@@ -575,7 +580,7 @@ Access Restrictions {#access}
 -------------------
 
 The information in the Client Hints defined above reveals quite a bit of information about the user
-agent and the platform/device upon which it runs. [=User agents=] ought to exercise judgement before
+agent and the device upon which it runs. [=User agents=] ought to exercise judgement before
 granting access to this information, and MAY impose restrictions above and beyond the secure
 transport and delegation requirements noted above. For instance, [=user agents=] could choose to reveal
 [=user agent/platform architecture=] or [=user agent/platform bitness=] only on requests it intends

--- a/index.bs
+++ b/index.bs
@@ -235,6 +235,30 @@ platforms where the model is typically exposed.
 [=User agents=] MAY return the empty string or a fictitious value for [=full version=], [=platform
 architecture=], [=platform bitness=] or [=model=], for privacy, compatibility, or other reasons.
 
+The 'Sec-CH-UA' Header Field {#sec-ch-ua}
+----------------------------
+
+The <dfn http-header>`Sec-CH-UA`</dfn> request header field gives a server information about a
+[=user agent=]'s branding and version. It is a [=Structured Header=] whose value MUST be a
+[=structured header/list=] [[!RFC8941]]. The list's items MUST be
+[=structured header/string=]. The value of each item SHOULD include a "v" parameter, indicating the
+[=user agent=]'s version.
+
+The header's ABNF is:
+
+``` abnf
+  Sec-CH-UA = sf-list
+```
+
+Note: Unlike most Client Hints, since it's included in the [=low entropy hint table=],
+the `Sec-CH-UA` header will be sent by default, whether or not the server opted-into
+receiving the header via an `Accept-CH` header (although it can still be controlled by it's
+[=policy controlled client hints feature=].
+It is considered low entropy because it includes only the [=user agent=]'s branding information,
+and the significant version number (both of which are fairly clearly sniffable by "examining the
+structure of other headers and by testing for the availability and semantics of the features
+introduced or modified between releases of a particular browser" [[Janc2014]]).
+
 The 'Sec-CH-UA-Arch' Header Field {#sec-ch-ua-arch}
 ------------------------------
 
@@ -262,6 +286,39 @@ The header's ABNF is:
 ~~~ abnf
   Sec-CH-UA-Bitness = sf-string
 ~~~
+
+The 'Sec-CH-UA-Full-Version' Header Field {#sec-ch-ua-full-version}
+--------------------------------
+
+The <dfn http-header>`Sec-CH-UA-Full-Version`</dfn> request header field gives a server information
+about the user agent's [=user agent/full version=]. It is a [=Structured Header=]
+whose value MUST be a [=structured header/string=] [[!RFC8941]].
+
+The header's ABNF is:
+
+``` abnf
+  Sec-CH-UA-Full-Version = sf-string
+```
+
+The 'Sec-CH-UA-Mobile' Header Field {#sec-ch-ua-mobile}
+--------------------------------
+
+The <dfn http-header>`Sec-CH-UA-Mobile`</dfn> request header field gives a server information about
+whether or not a [=user agent=] prefers a "mobile" user experience. It is a [=Structured Header=]
+whose value MUST be a [=structured header/boolean=] [[!RFC8941]].
+
+The header's ABNF is:
+
+``` abnf
+  Sec-CH-UA-Mobile = sf-boolean
+```
+
+Note: Like `Sec-CH-UA` above, since it's included in the [=low entropy hint table=],
+the `Sec-CH-UA-Mobile` header will be sent by default, whether or not the server opted-into
+receiving the header via an `Accept-CH` header (although it can still be controlled by it's
+[=policy controlled client hints feature=].
+It is considered low enropy because it is a single bit of information directly controllable
+by the user.
 
 The 'Sec-CH-UA-Model' Header Field {#sec-ch-ua-model}
 -------------------------------
@@ -307,30 +364,6 @@ The header's ABNF is:
   Sec-CH-UA-Platform-Version = sf-string
 ```
 
-The 'Sec-CH-UA' Header Field {#sec-ch-ua}
-----------------------------
-
-The <dfn http-header>`Sec-CH-UA`</dfn> request header field gives a server information about a
-[=user agent=]'s branding and version. It is a [=Structured Header=] whose value MUST be a
-[=structured header/list=] [[!RFC8941]]. The list's items MUST be
-[=structured header/string=]. The value of each item SHOULD include a "v" parameter, indicating the
-[=user agent=]'s version.
-
-The header's ABNF is:
-
-``` abnf
-  Sec-CH-UA = sf-list
-```
-
-Note: Unlike most Client Hints, since it's included in the [=low entropy hint table=],
-the `Sec-CH-UA` header will be sent by default, whether or not the server opted-into
-receiving the header via an `Accept-CH` header (although it can still be controlled by it's
-[=policy controlled client hints feature=].
-It is considered low entropy because it includes only the [=user agent=]'s branding information,
-and the significant version number (both of which are fairly clearly sniffable by "examining the
-structure of other headers and by testing for the availability and semantics of the features
-introduced or modified between releases of a particular browser" [[Janc2014]]).
-
 
 To <dfn abstract-op local-lt="set-ua">return the `Sec-CH-UA` value for a request</dfn>, [=user agents=] MUST:
 
@@ -349,39 +382,6 @@ To <dfn abstract-op local-lt="set-ua">return the `Sec-CH-UA` value for a request
     3. Append |pair| to |list|.
 
 3. Return the output of running [=serializing a list=] with |list| as input.
-
-The 'Sec-CH-UA-Full-Version' Header Field {#sec-ch-ua-full-version}
---------------------------------
-
-The <dfn http-header>`Sec-CH-UA-Full-Version`</dfn> request header field gives a server information
-about the user agent's [=user agent/full version=]. It is a [=Structured Header=]
-whose value MUST be a [=structured header/string=] [[!RFC8941]].
-
-The header's ABNF is:
-
-``` abnf
-  Sec-CH-UA-Full-Version = sf-string
-```
-
-The 'Sec-CH-UA-Mobile' Header Field {#sec-ch-ua-mobile}
---------------------------------
-
-The <dfn http-header>`Sec-CH-UA-Mobile`</dfn> request header field gives a server information about
-whether or not a [=user agent=] prefers a "mobile" user experience. It is a [=Structured Header=]
-whose value MUST be a [=structured header/boolean=] [[!RFC8941]].
-
-The header's ABNF is:
-
-``` abnf
-  Sec-CH-UA-Mobile = sf-boolean
-```
-
-Note: Like `Sec-CH-UA` above, since it's included in the [=low entropy hint table=],
-the `Sec-CH-UA-Mobile` header will be sent by default, whether or not the server opted-into
-receiving the header via an `Accept-CH` header (although it can still be controlled by it's
-[=policy controlled client hints feature=].
-It is considered low enropy because it is a single bit of information directly controllable
-by the user.
 
 Note: These client hints can be evoked with the following set of [=Client hints tokens=]:
 `Sec-CH-UA-Arch`, `Sec-CH-UA-Model`, `Sec-CH-UA-Platform`, `Sec-CH-UA`, `Sec-CH-UA-Mobile`
@@ -660,11 +660,25 @@ Therefore, request headers defined in this specification include a `Sec-CH-` pre
 IANA Considerations {#iana}
 ===================
 
-This document intends to define the `Sec-CH-UA-Arch`, `Sec-CH-UA-Model`, `Sec-CH-UA-Platform`,
-`Sec-CH-UA-Platform-Version`, `Sec-CH-UA-Mobile` and `Sec-CH-UA` HTTP request header fields, and
-register them in the permanent message header field registry ([[RFC3864]]).
+This document intends to define the `Sec-CH-UA`, `Sec-CH-UA-Arch`, `Sec-CH-UA-Bitness`,
+`Sec-CH-UA-Full-Version`, `Sec-CH-UA-Mobile`, `Sec-CH-UA-Model`, `Sec-CH-UA-Platform`, and the
+`Sec-CH-UA-Platform-Version` HTTP request header fields, and register them in the permanent message
+header field registry ([[RFC3864]]).
 
 It also intends to deprecate usage of the `User-Agent` header field.
+
+'Sec-CH-UA' Header Field {#iana-ua}
+------------------------
+
+Header field name: Sec-CH-UA
+
+Applicable protocol: http
+
+Status: standard
+
+Author/Change controller: IETF
+
+Specification document: this specification ([[#sec-ch-ua]])
 
 'Sec-CH-UA-Arch' Header Field {#iana-arch}
 --------------------------
@@ -691,6 +705,32 @@ Status: standard
 Author/Change controller: IETF
 
 Specification document: this specification ([[#sec-ch-ua-bitness]])
+
+'Sec-CH-UA-Full-Version' Header Field {#iana-full-version}
+----------------------------
+
+Header field name: Sec-CH-UA-Full-Version
+
+Applicable protocol: http
+
+Status: standard
+
+Author/Change controller: IETF
+
+Specification document: this specification ([[#sec-ch-ua-full-version]])
+
+'Sec-CH-UA-Mobile' Header Field {#iana-mobile}
+----------------------------
+
+Header field name: Sec-CH-UA-Mobile
+
+Applicable protocol: http
+
+Status: standard
+
+Author/Change controller: IETF
+
+Specification document: this specification ([[#sec-ch-ua-mobile]])
 
 'Sec-CH-UA-Model' Header Field {#iana-model}
 ---------------------------
@@ -730,45 +770,6 @@ Status: standard
 Author/Change controller: IETF
 
 Specification document: this specification ([[#sec-ch-ua-platform-version]])
-
-'Sec-CH-UA' Header Field {#iana-ua}
-------------------------
-
-Header field name: Sec-CH-UA
-
-Applicable protocol: http
-
-Status: standard
-
-Author/Change controller: IETF
-
-Specification document: this specification ([[#sec-ch-ua]])
-
-'Sec-CH-UA-Mobile' Header Field {#iana-mobile}
-----------------------------
-
-Header field name: Sec-CH-UA-Mobile
-
-Applicable protocol: http
-
-Status: standard
-
-Author/Change controller: IETF
-
-Specification document: this specification ([[#sec-ch-ua-mobile]])
-
-'Sec-CH-UA-Full-Version' Header Field {#iana-full-version}
-----------------------------
-
-Header field name: Sec-CH-UA-Full-Version
-
-Applicable protocol: http
-
-Status: standard
-
-Author/Change controller: IETF
-
-Specification document: this specification ([[#sec-ch-ua-full-version]])
 
 'User-Agent' Header Field {#iana-user-agent}
 -------------------------


### PR DESCRIPTION
(I did some alphabetizing of the header sections, so reviewing commit by commit might be less messy - the normative changes are all in d15da06)

PTAL @amtunlimited @yoavweiss 

(this still needs a PR against infra before merging)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/miketaylr/ua-client-hints/pull/221.html" title="Last updated on Apr 1, 2021, 6:03 PM UTC (d15da06)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/ua-client-hints/221/c8719a3...miketaylr:d15da06.html" title="Last updated on Apr 1, 2021, 6:03 PM UTC (d15da06)">Diff</a>