### PR TITLE
Fixes #196 - Add a Sec-CH-UA-Full-Version-List client hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ accomplish this as follows:
       readonly attribute FrozenArray<NavigatorUABrandVersion> brands; // [ {brand: "Google Chrome", version: "84"}, {brand: "Chromium", version: "84"} ]
       readonly attribute boolean mobile; // false
       readonly attribute platform; // "PhoneOS"
-      Promise<UADataValues> getHighEntropyValues(sequence<DOMString> hints); // [ "arm", "64", "X644GTM", "PhoneOS", "10A", "73.32.AGX.5" ]
+      Promise<UADataValues> getHighEntropyValues(sequence<DOMString> hints); // { architecture: "arm", bitness: "64", model: "X644GTM", platform: "PhoneOS", platformVersion: "10A", versionList: [ {brand: "Google Chrome", version: "84.1.2.3"}, {brand: "Chromium", version: "84.1.2.3"}, {brand: "Not A;Brand", version: "101.3.2.9"} ] }
     };
 
     interface mixin NavigatorUA {

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ accomplish this as follows:
         brand list. For example:
 
         ```http
-        Sec-CH-UA-Version-List: "Edge"; v="92.0.902.73", "Chromium"; v="92.0.4515.131", "?Not:Your Browser"; v="3.1.2.0"
+        Sec-CH-UA-Version-List: "Microsoft Edge"; v="92.0.902.73", "Chromium"; v="92.0.4515.131", "?Not:Your Browser"; v="3.1.2.0"
         ```
 
 4.  These client hints should also be exposed via JavaScript APIs via a new

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ a corresponding JavaScript API:
 * `Sec-CH-UA-Platform`
 * `Sec-CH-UA-Platform-Version`
 * `Sec-CH-UA`
-* `Sec-CH-UA-Full-Version` (deprecated in favor of `Sec-CH-UA-Version-List`)
-* `Sec-CH-UA-Version-List`
+* `Sec-CH-UA-Full-Version` (deprecated in favor of `Sec-CH-UA-Full-Version-List`)
+* `Sec-CH-UA-Full-Version-List`
 
 
 ## Contributing
@@ -221,7 +221,7 @@ accomplish this as follows:
         ```
 
         Advisement: `Sec-CH-UA-Full-Version` is deprecated and will be removed in the future.
-        Developers should use `Sec-CH-UA-Version-List` instead.
+        Developers should use `Sec-CH-UA-Full-Version-List` instead.
 
     1.  The `Sec-CH-UA-Platform` header field represents the platform's brand and major version. For
         example:
@@ -230,11 +230,11 @@ accomplish this as follows:
         Sec-CH-UA-Platform: "Windows"
         ```
 
-    1.  The `Sec-CH-UA-Version-List` header field represents the full version for each brand in its
+    1.  The `Sec-CH-UA-Full-Version-List` header field represents the full version for each brand in its
         brand list. For example:
 
         ```http
-        Sec-CH-UA-Version-List: "Microsoft Edge"; v="92.0.902.73", "Chromium"; v="92.0.4515.131", "?Not:Your Browser"; v="3.1.2.0"
+        Sec-CH-UA-Full-Version-List: "Microsoft Edge"; v="92.0.902.73", "Chromium"; v="92.0.4515.131", "?Not:Your Browser"; v="3.1.2.0"
         ```
 
 4.  These client hints should also be exposed via JavaScript APIs via a new
@@ -252,11 +252,11 @@ accomplish this as follows:
       boolean mobile;             // true
       DOMString architecture;     // "arm"
       DOMString bitness;          // "64"
+      FrozenArray&lt;NavigatorUABrandVersion&gt; fullVersionList; // [ {brand: "Google Chrome", version: "84.0.4147.0"}, {brand: "Chromium", version: "84.0.4147"} ]
       DOMString model;            // "X644GTM"
       DOMString platform;         // "PhoneOS"
       DOMString platformVersion;  // "10A"
-      DOMString uaFullVersion; // deprecated in favor of versionList
-      FrozenArray&lt;NavigatorUABrandVersion&gt; versionList; // [ {brand: "Google Chrome", version: "84.0.4147.0"}, {brand: "Chromium", version: "84.0.4147"} ]
+      DOMString uaFullVersion; // deprecated in favor of fullVersionList
     };
 
     [Exposed=(Window,Worker)]
@@ -264,7 +264,7 @@ accomplish this as follows:
       readonly attribute FrozenArray<NavigatorUABrandVersion> brands; // [ {brand: "Google Chrome", version: "84"}, {brand: "Chromium", version: "84"} ]
       readonly attribute boolean mobile; // false
       readonly attribute platform; // "PhoneOS"
-      Promise<UADataValues> getHighEntropyValues(sequence<DOMString> hints); // { architecture: "arm", bitness: "64", model: "X644GTM", platform: "PhoneOS", platformVersion: "10A", versionList: [ {brand: "Google Chrome", version: "84.1.2.3"}, {brand: "Chromium", version: "84.1.2.3"}, {brand: "Not A;Brand", version: "101.3.2.9"} ] }
+      Promise<UADataValues> getHighEntropyValues(sequence<DOMString> hints); // { architecture: "arm", bitness: "64", model: "X644GTM", platform: "PhoneOS", platformVersion: "10A", fullVersionList: [ {brand: "Google Chrome", version: "84.1.2.3"}, {brand: "Chromium", version: "84.1.2.3"}, {brand: "Not A;Brand", version: "101.3.2.9"} ] }
     };
 
     interface mixin NavigatorUA {
@@ -306,7 +306,7 @@ Sec-CH-UA-Platform: “Windows”
 If a server delivers the following response header:
 
 ```http
-Accept-CH: Sec-CH-UA-Version-List, Sec-CH-UA-Arch
+Accept-CH: Sec-CH-UA-Full-Version-List, Sec-CH-UA-Arch
 ```
 
 Then subsequent requests to `https://example.com` will include the following request headers:
@@ -317,7 +317,7 @@ User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML,
 Sec-CH-UA: "Chrome"; v="74", ";Not)Your=Browser"; v="13"
 Sec-CH-UA-Mobile: ?0
 Sec-CH-UA-Platform: "Windows"
-Sec-CH-UA-Version-List: "Chrome"; v="74.0.3729.0", "Chromium"; v="74.0.3729.0", "?Not:Your Browser"; v="13.0.1.0"
+Sec-CH-UA-Full-Version-List: "Chrome"; v="74.0.3729.0", "Chromium"; v="74.0.3729.0", "?Not:Your Browser"; v="13.0.1.0"
 Sec-CH-UA-Arch: "arm"
 ```
 
@@ -335,12 +335,12 @@ Sec-CH-UA-Mobile: ?0
 Sec-CH-UA-Platform: “Windows”
 ```
 
-The server responds that the `Sec-CH-UA-Version-List` is required on first-request in order to
+The server responds that the `Sec-CH-UA-Full-Version-List` is required on first-request in order to
 deliver some optimized resource, for example:
 
 ```http
-Accept-CH: Sec-CH-UA-Version-List
-Critical-CH: Sec-CH-UA-Version-List
+Accept-CH: Sec-CH-UA-Full-Version-List
+Critical-CH: Sec-CH-UA-Full-Version-List
 ```
 
 The client then retries the initial request with the requested hints:
@@ -351,7 +351,7 @@ User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML,
 Sec-CH-UA: "Chrome"; v="74", ";Not)Your=Browser"; v="13"
 Sec-CH-UA-Mobile: ?0
 Sec-CH-UA-Platform: “Windows”
-Sec-CH-UA-Version-List: "Chrome"; v="74.0.3729.0", "Chromium"; v="74.0.3729.0", "?Not:Your Browser"; v="13.0.1.0"
+Sec-CH-UA-Full-Version-List: "Chrome"; v="74.0.3729.0", "Chromium"; v="74.0.3729.0", "?Not:Your Browser"; v="13.0.1.0"
 ```
 
 The user agent can make reasonable decisions about when to honor requests for detailed user agent

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ a corresponding JavaScript API:
 * `Sec-CH-UA-Platform`
 * `Sec-CH-UA-Platform-Version`
 * `Sec-CH-UA`
-* `Sec-CH-UA-Full-Version`
+* `Sec-CH-UA-Full-Version` (deprecated in favor of `Sec-CH-UA-Version-List`)
+* `Sec-CH-UA-Version-List`
 
 
 ## Contributing
@@ -219,11 +220,21 @@ accomplish this as follows:
         Sec-CH-UA-Full-Version: "73.1.2343B.TR"
         ```
 
+        Advisement: `Sec-CH-UA-Full-Version` is deprecated and will be removed in the future.
+        Developers should use `Sec-CH-UA-Version-List` instead.
+
     1.  The `Sec-CH-UA-Platform` header field represents the platform's brand and major version. For
         example:
 
         ```http
         Sec-CH-UA-Platform: "Windows"
+        ```
+
+    1.  The `Sec-CH-UA-Version-List` header field represents the full version for each brand in its
+        brand list. For example:
+
+        ```http
+        Sec-CH-UA-Version-List: "Edge"; v="92.0.902.73", "Chromium"; v="92.0.4515.131", "?Not:Your Browser"; v="3.1.2.0"
         ```
 
 4.  These client hints should also be exposed via JavaScript APIs via a new
@@ -237,12 +248,15 @@ accomplish this as follows:
     };
 
     dictionary UADataValues {
+      FrozenArray&lt;NavigatorUABrandVersion&gt; brands; // [ {brand: "Google Chrome", version: "84"}, {brand: "Chromium", version: "84"} ]
+      boolean mobile;             // true
       DOMString architecture;     // "arm"
       DOMString bitness;          // "64"
       DOMString model;            // "X644GTM"
       DOMString platform;         // "PhoneOS"
       DOMString platformVersion;  // "10A"
-      DOMString uaFullVersion;    // "73.32.AGX.5"
+      DOMString uaFullVersion; // deprecated in favor of versionList
+      FrozenArray&lt;NavigatorUABrandVersion&gt; versionList; // [ {brand: "Google Chrome", version: "84.0.4147.0"}, {brand: "Chromium", version: "84.0.4147"} ]
     };
 
     [Exposed=(Window,Worker)]
@@ -250,7 +264,7 @@ accomplish this as follows:
       readonly attribute FrozenArray<NavigatorUABrandVersion> brands; // [ {brand: "Google Chrome", version: "84"}, {brand: "Chromium", version: "84"} ]
       readonly attribute boolean mobile; // false
       readonly attribute platform; // "PhoneOS"
-      Promise<UADataValues> getHighEntropyValues(sequence<DOMString> hints); // { "arm", "64", "X644GTM", "PhoneOS", "10A", "73.32.AGX.5" }
+      Promise<UADataValues> getHighEntropyValues(sequence<DOMString> hints); // [ "arm", "64", "X644GTM", "PhoneOS", "10A", "73.32.AGX.5" ]
     };
 
     interface mixin NavigatorUA {
@@ -292,7 +306,7 @@ Sec-CH-UA-Platform: “Windows”
 If a server delivers the following response header:
 
 ```http
-Accept-CH: Sec-CH-UA-Full-Version, Sec-CH-UA-Arch
+Accept-CH: Sec-CH-UA-Version-List, Sec-CH-UA-Arch
 ```
 
 Then subsequent requests to `https://example.com` will include the following request headers:
@@ -303,7 +317,7 @@ User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML,
 Sec-CH-UA: "Chrome"; v="74", ";Not)Your=Browser"; v="13"
 Sec-CH-UA-Mobile: ?0
 Sec-CH-UA-Platform: "Windows"
-Sec-CH-UA-Full-Version: "74.0.3424.124"
+Sec-CH-UA-Version-List: "Chrome"; v="74.0.3729.0", "Chromium"; v="74.0.3729.0", "?Not:Your Browser"; v="13.0.1.0"
 Sec-CH-UA-Arch: "arm"
 ```
 
@@ -321,12 +335,12 @@ Sec-CH-UA-Mobile: ?0
 Sec-CH-UA-Platform: “Windows”
 ```
 
-The server responds that the `Sec-CH-UA-Full-Version` is required on first-request in order to
+The server responds that the `Sec-CH-UA-Version-List` is required on first-request in order to
 deliver some optimized resource, for example:
 
 ```http
-Accept-CH: Sec-CH-UA-Full-Version
-Critical-CH: Sec-CH-UA-Full-Version
+Accept-CH: Sec-CH-UA-Version-List
+Critical-CH: Sec-CH-UA-Version-List
 ```
 
 The client then retries the initial request with the requested hints:
@@ -337,7 +351,7 @@ User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML,
 Sec-CH-UA: "Chrome"; v="74", ";Not)Your=Browser"; v="13"
 Sec-CH-UA-Mobile: ?0
 Sec-CH-UA-Platform: “Windows”
-Sec-CH-UA-Full-Version: “74.0.1234.5”
+Sec-CH-UA-Version-List: "Chrome"; v="74.0.3729.0", "Chromium"; v="74.0.3729.0", "?Not:Your Browser"; v="13.0.1.0"
 ```
 
 The user agent can make reasonable decisions about when to honor requests for detailed user agent
@@ -353,7 +367,7 @@ use the JavaScript API:
   const brands = uaData.brands;     // [ {brand: "Google Chrome", version: "84"}, {brand: "Chromium", version: "84"} ]
   const mobileness = uaData.mobile; // false
   const platform = uaData.platform; // “macOS”
-  (async ()=>{
+  (async () => {
     // `getHighEntropyValues()` returns a Promise, so needs to be `await`ed on.
     const highEntropyValues = await uaData.getHighEntropyValues(
       ["platformVersion", "architecture", “bitness”, "model", "uaFullVersion"]);

--- a/index.bs
+++ b/index.bs
@@ -694,7 +694,7 @@ dictionary NavigatorUABrandVersion {
 };
 
 dictionary UADataValues {
-  sequence&lt;NavigatorUABrandVersion&gt; brands;
+  FrozenArray&lt;NavigatorUABrandVersion&gt; brands;
   boolean mobile;
   DOMString architecture;
   DOMString bitness;
@@ -702,7 +702,7 @@ dictionary UADataValues {
   DOMString platform;
   DOMString platformVersion;
   DOMString uaFullVersion;
-  sequence&lt;NavigatorUABrandVersion&gt; versionList;
+  FrozenArray&lt;NavigatorUABrandVersion&gt; versionList;
 };
 
 dictionary UALowEntropyJSON {
@@ -739,9 +739,17 @@ Processing model {#processing}
 Each [=user agent=] has an associated <dfn for="user agent">brands</dfn>, which is a [=/list=] created by running
 [=create brands=] with [=user agent/significant version=] as <var ignore>versionType</var>.
 
-Every {{WindowOrWorkerGlobalScope}} object has an associated <dfn for="WindowOrWorkerGlobalScope">brands frozen array</dfn>,
-which is a <code><a interface>FrozenArray</a>&lt;<a dictionary>NavigatorUABrandVersion</a>></code>. It is initially the
-result of [=create a frozen array|creating a frozen array=] from the [=user agent=]'s [=brands=].
+Every {{WindowOrWorkerGlobalScope}} object has an associated
+<dfn for="WindowOrWorkerGlobalScope">brands frozen array</dfn>, which is a
+<code><a interface>FrozenArray</a>&lt;<a dictionary>NavigatorUABrandVersion</a>></code>. It is
+initially the result of [=create a frozen array|creating a frozen array=] from the [=user agent=]'s
+[=brands=].
+
+Additionally, every {{WindowOrWorkerGlobalScope}} object has an associated
+<dfn for="WindowOrWorkerGlobalScope">version list frozen array</dfn>, which is a
+<code><a interface>FrozenArray</a>&lt;<a dictionary>NavigatorUABrandVersion</a>></code>. It is
+initially the result of [=create a frozen array|creating a frozen array=] from the [=user agent=]'s
+[=brands=], with [=user agent/full version=] passed as an argument.
 
 <h4 algorithm="to create brands" id="create-ua-list-section">Create brands</h4>
 
@@ -825,7 +833,8 @@ ISSUE(wicg/ua-client-hints): We can improve upon when and why a UA decides to re
 3. Otherwise, run the following steps [=in parallel=]:
 
     1. Let |uaData| be a new {{UADataValues}}.
-    1. set |uaData|["{{UADataValues/brands}}"] to [=this=]'s [=relevant global object=]'s [=WindowOrWorkerGlobalScope/brands frozen array=].
+    1. set |uaData|["{{UADataValues/brands}}"] to [=this=]'s [=relevant global object=]'s
+        [=WindowOrWorkerGlobalScope/brands frozen array=].
     1. set |uaData|["{{UADataValues/mobile}}"] to the [=user agent=]'s [=user agent/mobileness=].
     1. set |uaData|["{{UADataValues/platform}}"] to the [=user agent=]'s [=user agent/platform brand=].
     1. If |hints| [=list/contains=] "architecture", set |uaData|["{{UADataValues/architecture}}"] to
@@ -836,11 +845,11 @@ ISSUE(wicg/ua-client-hints): We can improve upon when and why a UA decides to re
         [=user agent=]'s [=user agent/model=].
     1. If |hints| [=list/contains=] "platformVersion", set |uaData|["{{UADataValues/platformVersion}}"]
         to the [=user agent=]'s [=user agent/platform version=].
-    1. If |hints| [=list/contains=] "uaFullVersion", let |uaData|["{{UADataValues/uaFullVersion}}"]
-        be the the user agent's [=user agent/full version=].
-    1. If |hints| [=list/contains=] "versionList", let |uaData|["{{UADataValues/versionList}}"]
-        be the result of running the [=create brands=] steps, with [=user agent/full version=]
-        passed as an argument.
+    1. If |hints| [=list/contains=] "uaFullVersion", set |uaData|["{{UADataValues/uaFullVersion}}"]
+        to the user agent's [=user agent/full version=].
+    1. If |hints| [=list/contains=] "versionList", set |uaData|["{{UADataValues/versionList}}"]
+        to [=this=]'s [=relevant global object=]'s
+        [=WindowOrWorkerGlobalScope/version list frozen array=].
     1. [=Queue a task=] on the [=permission task source=] to [=resolve=] |p| with |uaData|.
 
 4.  Return |p|.

--- a/index.bs
+++ b/index.bs
@@ -769,8 +769,9 @@ steps, given the argument |versionType|:
 1.  The [=user agent=] SHOULD execute the following steps:
     1. [=list/Append=] one additional [=list/item=] to |list| containing a
         {{NavigatorUABrandVersion}} dictionary, initialized with
-        <a lt="create an arbitrary brand">arbitrary brand</a> and
-        <a lt="create an arbitrary version">arbitrary version</a> combinations.
+        <a lt="create an arbitrary brand">arbitrary brand</a> as {{NavigatorUABrandVersion/brand}}
+        and the result of <a lt="create an arbitrary version">creating an arbitrary version</a> with
+        |versionType| as {{NavigatorUABrandVersion/version}}.
     1.  Randomize the order of the [=list/items=] in |list|.
 
     Note: One approach to minimize caching variance when generating these random components could be to
@@ -809,8 +810,14 @@ To <dfn>create an arbitrary brand</dfn>, the [=user agent=] MUST run these steps
     Note: [=Structured Headers=] allows for escaped 0x22 (\") and 0x5C (\\) inside a [=structured header/string=], but
           these are known to not be web-compatible.
 
-To <dfn>create an arbitrary version</dfn>, return a [=/string=] that MUST match the format of the [=user agent=]'s
-[=user agent/significant version=], but MUST NOT match the value.
+To <dfn>create an arbitrary version</dfn> with |versionType|, run the following steps:
+    1. Let |arbitraryVersion| be a [=/string=].
+    1. If |versionType| is [=user agent/significant version=], set |arbitraryVersion| to a string
+        that matches the format of the [=user agent=]'s [=user agent/significant version=], but not
+        the value.
+    1. If |versionType| is [=user agent/full version=], set |arbitraryVersion| to to a string that
+        matches the format of the [=user agent=]'s [=user agent/full version=], but not the value.
+    1. Return |arbitraryVersion|.
 
 Note: User Agents may decide to send arbitrarily low versions to ensure proper version checking, and should vary them
 over time.

--- a/index.bs
+++ b/index.bs
@@ -485,23 +485,19 @@ The header's ABNF is:
   Sec-CH-UA = sf-list
 ```
 
-To <dfn abstract-op local-lt="set-ua">return the `Sec-CH-UA` value for a request</dfn>, [=user agents=] MUST:
+To <dfn abstract-op>return the `Sec-CH-UA` value for a request</dfn>,
+[=user agents=] MUST:
 
-1.  Let |list| be a [=/list=], initially empty.
-
-2. For each |brandVersion| in [=user agent/brands=]:
-
+1. Let |list| be a [=/list=], initially empty.
+1. Let |brands| be the result of running the [=create brands=] steps, with
+    [=user agent/significant version=] passed as an argument.
+1. For each |brand| in |brands|:
     1. Let |parameter| be a [=dictionary=], initially empty.
-
-    2. Set |parameter|["param_name"] to "v".
-
-    3. Set |parameter|["param_value"] to |brandVersion|'s {{NavigatorUABrandVersion/version}}.
-
-    2. Let |pair| be a tuple comprised of |brandVersion|'s {{NavigatorUABrandVersion/brand}} and |parameter|.
-
-    3. Append |pair| to |list|.
-
-3. Return the output of running [=serializing a list=] with |list| as input.
+    1. Set |parameter|["param_name"] to "v".
+    1. Set |parameter|["param_value"] to |brand|'s {{NavigatorUABrandVersion/version}}.
+    1. Let |pair| be a tuple comprised of |brand|'s {{NavigatorUABrandVersion/brand}} and |parameter|.
+    1. Append |pair| to |list|.
+1. Return the output of running [=serializing a list=] with |list| as input.
 
 Note: Unlike most Client Hints, since it's included in the [=low entropy hint table=],
 the `Sec-CH-UA` header will be sent by default, whether or not the server opted-into
@@ -713,43 +709,37 @@ Processing model {#processing}
 <h4 id="monkeypatch-html-windoworworkerglobalscope"><code>WindowOrWorkerGlobalScope</code></h4>
 
 Each [=user agent=] has an associated <dfn for="user agent">brands</dfn>, which is a [=/list=] created by running
-[=create brands=].
+[=create brands=] with [=user agent/significant version=] as <var ignore>versionType</var>.
 
 Every {{WindowOrWorkerGlobalScope}} object has an associated <dfn for="WindowOrWorkerGlobalScope">brands frozen array</dfn>,
 which is a <code><a interface>FrozenArray</a>&lt;<a dictionary>NavigatorUABrandVersion</a>></code>. It is initially the
 result of [=create a frozen array|creating a frozen array=] from the [=user agent=]'s [=brands=].
 
-<h4 id="create-ua-list-section">Create brands</h4>
+<h4 algorithm="to create brands" id="create-ua-list-section">Create brands</h4>
 
-When asked to run the <dfn>create brands</dfn> algorithm, the [=user agent=] MUST run the following steps:
+When asked to run the <dfn>create brands</dfn> algorithm, the [=user agent=] MUST run the following
+steps, given the argument |versionType|:
+
 1. Let |list| be a [=/list=].
-
-2. Collect pairs of [=user agent/brand=] and [=user agent/significant version=] which represent the [=user agent=] or
-    [=equivalence classes=].
-
-3. For each pair:
-
-    1. Let |dict| be a new {{NavigatorUABrandVersion}} dictionary,
-        with [=user agent/brand=] as {{NavigatorUABrandVersion/brand}} and [=user agent/significant version=] as
-        {{NavigatorUABrandVersion/version}}.
-
-    2. Append |dict| to |list|.
-
-4.  The [=user agent=] SHOULD execute the following steps:
-
-    1.  [=list/Append=] one additional [=list/item=] to |list| containing a {{NavigatorUABrandVersion}} dictionary,
-        initialized with <a lt="create an arbitrary brand">arbitrary brand</a> and <a lt="create an arbitrary version">
-        arbitrary version</a> combinations.
-
-    2.  Randomize the order of the [=list/items=] in |list|.
+1. Collect pairs of [=user agent/brand=] and versions of |versionType| which represent the
+    [=user agent=] or [=equivalence classes=].
+1. For each pair:
+    1. Let |dict| be a new {{NavigatorUABrandVersion}} dictionary, with [=user agent/brand=] as
+        {{NavigatorUABrandVersion/brand}} and |versionType| as {{NavigatorUABrandVersion/version}}.
+    1. Append |dict| to |list|.
+1.  The [=user agent=] SHOULD execute the following steps:
+    1. [=list/Append=] one additional [=list/item=] to |list| containing a
+        {{NavigatorUABrandVersion}} dictionary, initialized with
+        <a lt="create an arbitrary brand">arbitrary brand</a> and
+        <a lt="create an arbitrary version">arbitrary version</a> combinations.
+    1.  Randomize the order of the [=list/items=] in |list|.
 
     Note: One approach to minimize caching variance when generating these random components could be to
     determine them at build time, and keep them identical throughout the lifetime of the [=user agent=]'s significant
     version.
 
     Note: See [[#grease]] for more details on when and why these randomization steps might be appropriate.
-
-5. Return |list|.
+1. Return |list|.
 
 An <dfn for="user agent" export>equivalence class</dfn> represents a group of browsers believed to be compatibile with
 each other. A shared rendering engine may form an [=equivalence class=], for example.

--- a/index.bs
+++ b/index.bs
@@ -537,7 +537,7 @@ The 'Sec-CH-UA-Full-Version' Header Field {#sec-ch-ua-full-version}
 --------------------------------
 
 Advisement: `Sec-CH-UA-Full-Version` is deprecated and will be removed in the future. Developers
-should use <a href="#sec-ch-ua-version-list">`Sec-CH-UA-Version-List`</a> instead.
+should use <a href="#sec-ch-ua-full-version-list">`Sec-CH-UA-Full-Version-List`</a> instead.
 
 The <dfn http-header>`Sec-CH-UA-Full-Version`</dfn> request header field gives a server information
 about the user agent's [=user agent/full version=]. It is a [=Structured Header=]
@@ -652,20 +652,20 @@ The header's ABNF is:
   Sec-CH-UA-Platform-Version = sf-string
 ```
 
-The 'Sec-CH-UA-Version-List' Header Field {#sec-ch-ua-version-list}
+The 'Sec-CH-UA-Full-Version-List' Header Field {#sec-ch-ua-full-version-list}
 --------------------------------
 
-The <dfn http-header>`Sec-CH-UA-Version-List`</dfn> request header field gives a server information
-about the [=user agent/full version=] for each brand in its [=brands=] list. It is a
+The <dfn http-header>`Sec-CH-UA-Full-Version-List`</dfn> request header field gives a server
+information about the [=user agent/full version=] for each brand in its [=brands=] list. It is a
 [=Structured Header=] whose value MUST be a [=structured header/list=] [[!RFC8941]].
 
 The header's ABNF is:
 
 ``` abnf
-  Sec-CH-UA-Version-List = sf-list
+  Sec-CH-UA-Full-Version-List = sf-list
 ```
 
-To <dfn abstract-op>return the `Sec-CH-UA-Version-List` value for a request</dfn>, perform the
+To <dfn abstract-op>return the `Sec-CH-UA-Full-Version-List` value for a request</dfn>, perform the
 following steps:
 
 1. Let |version type| be the type [=user agent/full version=].
@@ -677,7 +677,7 @@ following steps:
 
 Note: These client hints can be evoked with the following set of [=client hints tokens=]:
 `Sec-CH-UA`, `Sec-CH-UA-Arch`, `Sec-CH-UA-Bitness`, `Sec-CH-UA-Full-Version`, `Sec-CH-UA-Mobile`,
-`Sec-CH-UA-Model`, `Sec-CH-UA-Platform`, `Sec-CH-UA-Platform-Version`, `Sec-CH-UA-Version-List`
+`Sec-CH-UA-Model`, `Sec-CH-UA-Platform`, `Sec-CH-UA-Platform-Version`, `Sec-CH-UA-Full-Version-List`
 
 Interface {#interface}
 =================
@@ -696,8 +696,8 @@ dictionary UADataValues {
   DOMString model;
   DOMString platform;
   DOMString platformVersion;
-  DOMString uaFullVersion; // deprecated in favor of versionList
-  FrozenArray&lt;NavigatorUABrandVersion&gt; versionList;
+  DOMString uaFullVersion; // deprecated in favor of fullVersionList
+  FrozenArray&lt;NavigatorUABrandVersion&gt; fullVersionList;
 };
 
 dictionary UALowEntropyJSON {
@@ -866,7 +866,7 @@ ISSUE(wicg/ua-client-hints): We can improve upon when and why a UA decides to re
         to the [=user agent=]'s [=user agent/platform version=].
     1. If |hints| [=list/contains=] "uaFullVersion", set |uaData|["{{UADataValues/uaFullVersion}}"]
         to the user agent's [=user agent/full version=].
-    1. If |hints| [=list/contains=] "versionList", set |uaData|["{{UADataValues/versionList}}"]
+    1. If |hints| [=list/contains=] "fullVersionList", set |uaData|["{{UADataValues/fullVersionList}}"]
         to [=this=]'s [=relevant global object=]'s
         [=WindowOrWorkerGlobalScope/version list frozen array=].
     1. [=Queue a task=] on the [=permission task source=] to [=resolve=] |p| with |uaData|.
@@ -1009,7 +1009,7 @@ IANA Considerations {#iana}
 
 This document intends to define the `Sec-CH-UA`, `Sec-CH-UA-Arch`, `Sec-CH-UA-Bitness`,
 `Sec-CH-UA-Full-Version`, `Sec-CH-UA-Mobile`, `Sec-CH-UA-Model`, `Sec-CH-UA-Platform`,
-`Sec-CH-UA-Platform-Version`, and the `Sec-CH-UA-Version-List` HTTP request header fields, and
+`Sec-CH-UA-Platform-Version`, and the `Sec-CH-UA-Full-Version-List` HTTP request header fields, and
 register them in the permanent message header field registry ([[RFC3864]]).
 
 It also intends to deprecate usage of the `User-Agent` header field.
@@ -1118,10 +1118,10 @@ Author/Change controller: IETF
 
 Specification document: this specification ([[#sec-ch-ua-platform-version]])
 
-'Sec-CH-UA-Version-List' Header Field {#iana-version-list}
+'Sec-CH-UA-Full-Version-List' Header Field {#iana-full-version-list}
 -------------------------
 
-Header field name: Sec-CH-UA-Version-List
+Header field name: Sec-CH-UA-Full-Version-List
 
 Applicable protocol: http
 
@@ -1129,7 +1129,7 @@ Status: standard
 
 Author/Change controller: IETF
 
-Specification document: this specification ([[#sec-ch-ua-version-list]])
+Specification document: this specification ([[#sec-ch-ua-full-version-list]])
 
 'User-Agent' Header Field {#iana-user-agent}
 -------------------------

--- a/index.bs
+++ b/index.bs
@@ -428,10 +428,13 @@ has defined a number of properties for itself:
 
 *   <dfn for="user agent" export>brand</dfn> - The [=user agent=]'s commercial name (e.g.,
       "cURL", "Edge", "The World's Best Web Browser")
-*   <dfn for="user agent" export>significant version</dfn> - The [=user agent=]'s marketing version,
-      which includes distinguishable web-exposed features (e.g., "72", "3", or "12.1")
-*   <dfn for="user agent" export>full version</dfn> - The [=user agent=]'s build version (e.g.,
-      "72.0.3245.12", "3.14159", or "297.70E04154A")
+*   <dfn for="user agent" export>significant version</dfn> - The marketing version which includes
+      distinguishable web-exposed features (e.g., "72", "3", or "12.1"), corresponding to the
+      [=user agent=], or any of the brands in its [=brands=] list (e.g., rendering engine or
+      any other [=equivalence classes=] full version).
+*   <dfn for="user agent" export>full version</dfn> - The build version (e.g.,
+      "72.0.3245.12", "3.14159", or "297.70E04154A") that corresponds to the [=user agent=], or any
+      of the brands in its [=brands=] list.
 *   <dfn for="user agent" export>platform brand</dfn> - The [=user agent=]'s operating system's
       commercial name. (e.g., "Windows", "iOS", or "AmazingOS")
 *   <dfn for="user agent" export>platform version</dfn> - The [=user agent=]'s operating system's

--- a/index.bs
+++ b/index.bs
@@ -539,6 +539,9 @@ The header's ABNF is:
 The 'Sec-CH-UA-Full-Version' Header Field {#sec-ch-ua-full-version}
 --------------------------------
 
+Advisement: `Sec-CH-UA-Full-Version` is deprecated and will be removed in the future. Developers
+should use <a href="#sec-ch-ua-version-list">`Sec-CH-UA-Version-List`</a> instead.
+
 The <dfn http-header>`Sec-CH-UA-Full-Version`</dfn> request header field gives a server information
 about the user agent's [=user agent/full version=]. It is a [=Structured Header=]
 whose value MUST be a [=structured header/string=] [[!RFC8941]].
@@ -701,7 +704,7 @@ dictionary UADataValues {
   DOMString model;
   DOMString platform;
   DOMString platformVersion;
-  DOMString uaFullVersion;
+  DOMString uaFullVersion; // deprecated in favor of versionList
   FrozenArray&lt;NavigatorUABrandVersion&gt; versionList;
 };
 
@@ -1041,7 +1044,7 @@ Header field name: Sec-CH-UA-Full-Version
 
 Applicable protocol: http
 
-Status: standard
+Status: deprecated
 
 Author/Change controller: IETF
 

--- a/index.bs
+++ b/index.bs
@@ -169,7 +169,7 @@ In response, the user agent includes the platform version information in the nex
   Sec-CH-UA: "Examplary Browser"; v="73", ";Not?A.Brand"; v="27"
   Sec-CH-UA-Mobile: ?0
   Sec-CH-UA-Platform: "Windows"
-  Sec-CH-UA-Full-Version: "14.0.0"
+  Sec-CH-UA-Platform-Version: "14.0.0"
 ```
 
 ## Use Cases ## {#use-cases}

--- a/index.bs
+++ b/index.bs
@@ -486,17 +486,14 @@ The header's ABNF is:
 ```
 
 To <dfn abstract-op>return the `Sec-CH-UA` value for a request</dfn>,
-[=user agents=] MUST:
+[=user agents=] MUST run these steps:
 
-1. Let |list| be a [=/list=], initially empty.
-1. Let |brands| be the result of running the [=create brands=] steps, with
-    [=user agent/significant version=] passed as an argument.
-1. For each |brand| in |brands|:
-    1. Let |parameter| be a [=dictionary=], initially empty.
-    1. Set |parameter|["param_name"] to "v".
-    1. Set |parameter|["param_value"] to |brand|'s {{NavigatorUABrandVersion/version}}.
-    1. Let |pair| be a tuple comprised of |brand|'s {{NavigatorUABrandVersion/brand}} and |parameter|.
-    1. Append |pair| to |list|.
+1. Let |versionType| be the [=user agent=]'s [=user agent/significant version=].
+1. Let |brands| be the result of running the [=create brands=] steps, with |versionType| passed as
+    an argument.
+1. Let |list| be the result of
+    <a lt="create a brand-version list">creating a brand-version list</a>, with |brands| and
+    |versionType| passed as arguments.
 1. Return the output of running [=serializing a list=] with |list| as input.
 
 Note: Unlike most Client Hints, since it's included in the [=low entropy hint table=],
@@ -671,17 +668,13 @@ The header's ABNF is:
 To <dfn abstract-op>return the `Sec-CH-UA-Version-List` value for a request</dfn>, [=user agents=]
 MUST run the following steps:
 
-1. Let |versionList| be a [=/list=], initially empty.
+1. Let |versionType| be the [=user agent=]'s [=user agent/full version=].
 1. Let |brands| be the result of running the [=create brands=] steps, with
-    [=user agent/full version=] passed as an argument.
-1. For each |brand| in |brands|:
-    1. Let |parameter| be a [=dictionary=], initially empty.
-    1. Set |parameter|["param_name"] to "v".
-    1. Set |parameter|["param_value"] to |brand|'s {{NavigatorUABrandVersion/version}}.
-    1. Let |pair| be a tuple comprised of |brand|'s {{NavigatorUABrandVersion/brand}} and
-        |parameter|.
-    1. Append |pair| to |versionList|.
-1. Return the output of running [=serializing a list=] with |versionList| as input.
+    |versionType| passed as an argument.
+1. Let |list| be the result of
+    <a lt="create a brand-version list">creating a brand-version list</a>, with
+    |brands| and |versionType| passed as arguments.
+1. Return the output of running [=serializing a list=] with |list| as input.
 
 Note: These client hints can be evoked with the following set of [=client hints tokens=]:
 `Sec-CH-UA`, `Sec-CH-UA-Arch`, `Sec-CH-UA-Bitness`, `Sec-CH-UA-Full-Version`, `Sec-CH-UA-Mobile`,
@@ -821,6 +814,22 @@ To <dfn>create an arbitrary version</dfn> with |versionType|, run the following 
 
 Note: User Agents may decide to send arbitrarily low versions to ensure proper version checking, and should vary them
 over time.
+
+<h4 id="create-brand-version-list"
+    algorithm="to create a brand-version list">Create a brand-version list</h4>
+
+To <dfn>create a brand-version list</dfn> with |brands| and |versionType|, the [=user agent=]
+ MUST run these steps:
+
+    1. Let |list| be a [=/list=], initially empty.
+    1. For each |brand| in |brands|:
+        1. Let |parameter| be a [=dictionary=], initially empty.
+        1. Set |parameter|["param_key"] to "v".
+        1. Set |parameter|["param_value"] to |versionType|.
+        1. Let |pair| be a tuple comprised of |brand|'s {{NavigatorUABrandVersion/brand}} and
+            |parameter|.
+        1. Append |pair| to |list|.
+    1. Return |list|.
 
 <h4 id="getters">Getters</h4>
 

--- a/index.bs
+++ b/index.bs
@@ -743,8 +743,8 @@ initially the result of [=create a frozen array|creating a frozen array=] from t
 Additionally, every {{WindowOrWorkerGlobalScope}} object has an associated
 <dfn for="WindowOrWorkerGlobalScope">version list frozen array</dfn>, which is a
 <code><a interface>FrozenArray</a>&lt;<a dictionary>NavigatorUABrandVersion</a>></code>. It is
-initially the result of [=create a frozen array|creating a frozen array=] from the [=user agent=]'s
-[=brands=], with [=user agent/full version=] passed as an argument.
+the result of [=create a frozen array|creating a frozen array=] from running [=create brands=] with
+[=user agent/full version=].
 
 <h4 algorithm="to create brands" id="create-ua-list-section">Create brands</h4>
 

--- a/index.bs
+++ b/index.bs
@@ -488,16 +488,13 @@ The header's ABNF is:
   Sec-CH-UA = sf-list
 ```
 
-To <dfn abstract-op>return the `Sec-CH-UA` value for a request</dfn>,
-[=user agents=] MUST run these steps:
+To <dfn abstract-op>return the `Sec-CH-UA` value for a request</dfn>, perform the following steps:
 
-1. Let |versionType| be the [=user agent=]'s [=user agent/significant version=].
-1. Let |brands| be the result of running the [=create brands=] steps, with |versionType| passed as
-    an argument.
-1. Let |list| be the result of
-    <a lt="create a brand-version list">creating a brand-version list</a>, with |brands| and
-    |versionType| passed as arguments.
-1. Return the output of running [=serializing a list=] with |list| as input.
+1. Let |version type| be the type [=user agent/significant version=].
+1. Let |brands| be the result of running [=create brands=] with |version type|.
+1. Let |list| be the result of <a lt="create a brand-version list">creating a brand-version list</a>,
+    with |brands| and |version type|.
+1. Return the output of running [=serializing a list=] with |list|.
 
 Note: Unlike most Client Hints, since it's included in the [=low entropy hint table=],
 the `Sec-CH-UA` header will be sent by default, whether or not the server opted-into
@@ -668,15 +665,14 @@ The header's ABNF is:
   Sec-CH-UA-Version-List = sf-list
 ```
 
-To <dfn abstract-op>return the `Sec-CH-UA-Version-List` value for a request</dfn>, [=user agents=]
-MUST run the following steps:
+To <dfn abstract-op>return the `Sec-CH-UA-Version-List` value for a request</dfn>, perform the
+following steps:
 
-1. Let |versionType| be the [=user agent=]'s [=user agent/full version=].
-1. Let |brands| be the result of running the [=create brands=] steps, with
-    |versionType| passed as an argument.
+1. Let |version type| be the type [=user agent/full version=].
+1. Let |brands| be the result of running [=create brands=] with |version type|.
 1. Let |list| be the result of
-    <a lt="create a brand-version list">creating a brand-version list</a>, with
-    |brands| and |versionType| passed as arguments.
+    <a lt="create a brand-version list">creating a brand-version list</a>, with |brands| and
+    |version type|.
 1. Return the output of running [=serializing a list=] with |list| as input.
 
 Note: These client hints can be evoked with the following set of [=client hints tokens=]:
@@ -735,8 +731,8 @@ Processing model {#processing}
 
 <h4 id="monkeypatch-html-windoworworkerglobalscope"><code>WindowOrWorkerGlobalScope</code></h4>
 
-Each [=user agent=] has an associated <dfn for="user agent">brands</dfn>, which is a [=/list=] created by running
-[=create brands=] with [=user agent/significant version=] as <var ignore>versionType</var>.
+Each [=user agent=] has an associated <dfn for="user agent">brands</dfn>, which is a [=/list=]
+created by running [=create brands=] with [=user agent/significant version=].
 
 Every {{WindowOrWorkerGlobalScope}} object has an associated
 <dfn for="WindowOrWorkerGlobalScope">brands frozen array</dfn>, which is a
@@ -752,22 +748,22 @@ initially the result of [=create a frozen array|creating a frozen array=] from t
 
 <h4 algorithm="to create brands" id="create-ua-list-section">Create brands</h4>
 
-When asked to run the <dfn>create brands</dfn> algorithm, the [=user agent=] MUST run the following
-steps, given the argument |versionType|:
+When asked to <dfn>create brands</dfn> with |version type|, run the following steps:
 
 1. Let |list| be a [=/list=].
-1. Collect pairs of [=user agent/brand=] and versions of |versionType| which represent the
+1. Collect pairs of [=user agent/brand=] and versions of type |version type| which represent the
     [=user agent=] or [=equivalence classes=].
 1. For each pair:
     1. Let |dict| be a new {{NavigatorUABrandVersion}} dictionary, with [=user agent/brand=] as
-        {{NavigatorUABrandVersion/brand}} and |versionType| as {{NavigatorUABrandVersion/version}}.
+        {{NavigatorUABrandVersion/brand}} and a string of type |version type| as
+        {{NavigatorUABrandVersion/version}}.
     1. Append |dict| to |list|.
 1.  The [=user agent=] SHOULD execute the following steps:
     1. [=list/Append=] one additional [=list/item=] to |list| containing a
         {{NavigatorUABrandVersion}} dictionary, initialized with
         <a lt="create an arbitrary brand">arbitrary brand</a> as {{NavigatorUABrandVersion/brand}}
         and the result of <a lt="create an arbitrary version">creating an arbitrary version</a> with
-        |versionType| as {{NavigatorUABrandVersion/version}}.
+        {{NavigatorUABrandVersion/version}}.
     1.  Randomize the order of the [=list/items=] in |list|.
 
     Note: One approach to minimize caching variance when generating these random components could be to
@@ -806,14 +802,14 @@ To <dfn>create an arbitrary brand</dfn>, the [=user agent=] MUST run these steps
     Note: [=Structured Headers=] allows for escaped 0x22 (\") and 0x5C (\\) inside a [=structured header/string=], but
           these are known to not be web-compatible.
 
-To <dfn>create an arbitrary version</dfn> with |versionType|, run the following steps:
-    1. Let |arbitraryVersion| be a [=/string=].
-    1. If |versionType| is [=user agent/significant version=], set |arbitraryVersion| to a string
+To <dfn>create an arbitrary version</dfn> given |version type|, run the following steps:
+    1. Let |arbitrary version| be a [=/string=].
+    1. If |version type| is [=user agent/significant version=], set |arbitrary version| to a string
         that matches the format of the [=user agent=]'s [=user agent/significant version=], but not
         the value.
-    1. If |versionType| is [=user agent/full version=], set |arbitraryVersion| to to a string that
+    1. If |version type| is [=user agent/full version=], set |arbitrary version| to to a string that
         matches the format of the [=user agent=]'s [=user agent/full version=], but not the value.
-    1. Return |arbitraryVersion|.
+    1. Return |arbitrary version|.
 
 Note: User Agents may decide to send arbitrarily low versions to ensure proper version checking, and should vary them
 over time.
@@ -821,14 +817,15 @@ over time.
 <h4 id="create-brand-version-list"
     algorithm="to create a brand-version list">Create a brand-version list</h4>
 
-To <dfn>create a brand-version list</dfn> with |brands| and |versionType|, the [=user agent=]
- MUST run these steps:
+To <dfn>create a brand-version list</dfn> given |brands| and |version type|, perform the following
+steps:
 
     1. Let |list| be a [=/list=], initially empty.
     1. For each |brand| in |brands|:
         1. Let |parameter| be a [=dictionary=], initially empty.
         1. Set |parameter|["param_key"] to "v".
-        1. Set |parameter|["param_value"] to |versionType|.
+        1. Set |parameter|["param_value"] to a string of type |version type| that corresponds
+            to |brand|.
         1. Let |pair| be a tuple comprised of |brand|'s {{NavigatorUABrandVersion/brand}} and
             |parameter|.
         1. Append |pair| to |list|.

--- a/index.bs
+++ b/index.bs
@@ -652,10 +652,37 @@ The header's ABNF is:
   Sec-CH-UA-Platform-Version = sf-string
 ```
 
+The 'Sec-CH-UA-Version-List' Header Field {#sec-ch-ua-version-list}
+--------------------------------
+
+The <dfn http-header>`Sec-CH-UA-Version-List`</dfn> request header field gives a server information
+about the [=user agent/full version=] for each brand in its [=brands=] list. It is a
+[=Structured Header=] whose value MUST be a [=structured header/list=] [[!RFC8941]].
+
+The header's ABNF is:
+
+``` abnf
+  Sec-CH-UA-Version-List = sf-list
+```
+
+To <dfn abstract-op>return the `Sec-CH-UA-Version-List` value for a request</dfn>, [=user agents=]
+MUST run the following steps:
+
+1. Let |versionList| be a [=/list=], initially empty.
+1. Let |brands| be the result of running the [=create brands=] steps, with
+    [=user agent/full version=] passed as an argument.
+1. For each |brand| in |brands|:
+    1. Let |parameter| be a [=dictionary=], initially empty.
+    1. Set |parameter|["param_name"] to "v".
+    1. Set |parameter|["param_value"] to |brand|'s {{NavigatorUABrandVersion/version}}.
+    1. Let |pair| be a tuple comprised of |brand|'s {{NavigatorUABrandVersion/brand}} and
+        |parameter|.
+    1. Append |pair| to |versionList|.
+1. Return the output of running [=serializing a list=] with |versionList| as input.
+
 Note: These client hints can be evoked with the following set of [=client hints tokens=]:
 `Sec-CH-UA`, `Sec-CH-UA-Arch`, `Sec-CH-UA-Bitness`, `Sec-CH-UA-Full-Version`, `Sec-CH-UA-Mobile`,
-`Sec-CH-UA-Model`, `Sec-CH-UA-Platform`, `Sec-CH-UA-Platform-Version`
-
+`Sec-CH-UA-Model`, `Sec-CH-UA-Platform`, `Sec-CH-UA-Platform-Version`, `Sec-CH-UA-Version-List`
 
 Interface {#interface}
 =================
@@ -669,12 +696,13 @@ dictionary NavigatorUABrandVersion {
 dictionary UADataValues {
   sequence&lt;NavigatorUABrandVersion&gt; brands;
   boolean mobile;
-  DOMString platform;
   DOMString architecture;
   DOMString bitness;
   DOMString model;
+  DOMString platform;
   DOMString platformVersion;
   DOMString uaFullVersion;
+  sequence&lt;NavigatorUABrandVersion&gt; versionList;
 };
 
 dictionary UALowEntropyJSON {
@@ -797,7 +825,6 @@ ISSUE(wicg/ua-client-hints): We can improve upon when and why a UA decides to re
 3. Otherwise, run the following steps [=in parallel=]:
 
     1. Let |uaData| be a new {{UADataValues}}.
-
     1. set |uaData|["{{UADataValues/brands}}"] to [=this=]'s [=relevant global object=]'s [=WindowOrWorkerGlobalScope/brands frozen array=].
     1. set |uaData|["{{UADataValues/mobile}}"] to the [=user agent=]'s [=user agent/mobileness=].
     1. set |uaData|["{{UADataValues/platform}}"] to the [=user agent=]'s [=user agent/platform brand=].
@@ -811,6 +838,9 @@ ISSUE(wicg/ua-client-hints): We can improve upon when and why a UA decides to re
         to the [=user agent=]'s [=user agent/platform version=].
     1. If |hints| [=list/contains=] "uaFullVersion", let |uaData|["{{UADataValues/uaFullVersion}}"]
         be the the user agent's [=user agent/full version=].
+    1. If |hints| [=list/contains=] "versionList", let |uaData|["{{UADataValues/versionList}}"]
+        be the result of running the [=create brands=] steps, with [=user agent/full version=]
+        passed as an argument.
     1. [=Queue a task=] on the [=permission task source=] to [=resolve=] |p| with |uaData|.
 
 4.  Return |p|.
@@ -950,9 +980,9 @@ IANA Considerations {#iana}
 ===================
 
 This document intends to define the `Sec-CH-UA`, `Sec-CH-UA-Arch`, `Sec-CH-UA-Bitness`,
-`Sec-CH-UA-Full-Version`, `Sec-CH-UA-Mobile`, `Sec-CH-UA-Model`, `Sec-CH-UA-Platform`, and the
-`Sec-CH-UA-Platform-Version` HTTP request header fields, and register them in the permanent message
-header field registry ([[RFC3864]]).
+`Sec-CH-UA-Full-Version`, `Sec-CH-UA-Mobile`, `Sec-CH-UA-Model`, `Sec-CH-UA-Platform`,
+`Sec-CH-UA-Platform-Version`, and the `Sec-CH-UA-Version-List` HTTP request header fields, and
+register them in the permanent message header field registry ([[RFC3864]]).
 
 It also intends to deprecate usage of the `User-Agent` header field.
 
@@ -1059,6 +1089,19 @@ Status: standard
 Author/Change controller: IETF
 
 Specification document: this specification ([[#sec-ch-ua-platform-version]])
+
+'Sec-CH-UA-Version-List' Header Field {#iana-version-list}
+-------------------------
+
+Header field name: Sec-CH-UA-Version-List
+
+Applicable protocol: http
+
+Status: standard
+
+Author/Change controller: IETF
+
+Specification document: this specification ([[#sec-ch-ua-version-list]])
 
 'User-Agent' Header Field {#iana-user-agent}
 -------------------------

--- a/index.bs
+++ b/index.bs
@@ -741,7 +741,7 @@ initially the result of [=create a frozen array|creating a frozen array=] from t
 [=brands=].
 
 Additionally, every {{WindowOrWorkerGlobalScope}} object has an associated
-<dfn for="WindowOrWorkerGlobalScope">version list frozen array</dfn>, which is a
+<dfn for="WindowOrWorkerGlobalScope">full version list frozen array</dfn>, which is a
 <code><a interface>FrozenArray</a>&lt;<a dictionary>NavigatorUABrandVersion</a>></code>. It is
 the result of [=create a frozen array|creating a frozen array=] from running [=create brands=] with
 [=user agent/full version=].
@@ -868,7 +868,7 @@ ISSUE(wicg/ua-client-hints): We can improve upon when and why a UA decides to re
         to the user agent's [=user agent/full version=].
     1. If |hints| [=list/contains=] "fullVersionList", set |uaData|["{{UADataValues/fullVersionList}}"]
         to [=this=]'s [=relevant global object=]'s
-        [=WindowOrWorkerGlobalScope/version list frozen array=].
+        [=WindowOrWorkerGlobalScope/full version list frozen array=].
     1. [=Queue a task=] on the [=permission task source=] to [=resolve=] |p| with |uaData|.
 
 4.  Return |p|.


### PR DESCRIPTION
TODO: 
* [x] deprecate `Sec-CH-UA-Full-Version`
* [x] should getHighEntropyHints return a FrozenArray for valueList?
* [x] update README
* [x] file corresponding CH Infra issue (to capture permissions policy), and coordinate landing that PR once this is ready
* [x] https://wicg.github.io/ua-client-hints/#create-an-arbitrary-version needs to be updated to take an argument as well


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Sep 13, 2021, 9:15 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fmiketaylr%2Fua-client-hints%2F8cc707f3fb3a11ed9ed645781c7bfeb1fd989a17%2Findex.bs&md-warning=not%20ready)

```
Error running preprocessor, returned code: 2.
FATAL ERROR: Couldn't load MDN Spec Links data for this spec.
Expecting value: line 1 column 1 (char 0)
 ✘  Did not generate, due to fatal errors
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20WICG/ua-client-hints%23250.)._
</details>
