### PR TITLE
Fixes #248 - Linux returns empty string for Sec-CH-UA-Platform-Version

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -615,6 +615,8 @@ information about the platform version on which a given [=user agent=] is execut
 [[!RFC8941]].
 
 [=User agents=] SHOULD return a version with a platform-specific format that allows differentiating significant platform versions by running these steps:
+    1. If the platform is Linux:
+    	1. Return the empty string.
     1. Let |platformVersionComponentList| be a [=list=].
     1. Use per-platform logic:
         * If the platform is Android:
@@ -622,9 +624,6 @@ information about the platform version on which a given [=user agent=] is execut
             1. Let |platformVersionComponentList| be the result of running <a lt="parse a platform-returned version string">parse a platform-returned version string</a> with |platformReturnedVersionString|.
         * If the platform is iOS:
             1. Let |platformReturnedVersionString| be the result of querying the `UIDevice` returned by `currentDevice` and reading its `systemVersion`.
-            1. Let |platformVersionComponentList| be the result of running <a lt="parse a platform-returned version string">parse a platform-returned version string</a> with |platformReturnedVersionString|.
-        * If the platform is Linux:
-            1. Let |platformReturnedVersionString| be the result of querying the `release` string in the `utsname` struct returned by the `uname` API.
             1. Let |platformVersionComponentList| be the result of running <a lt="parse a platform-returned version string">parse a platform-returned version string</a> with |platformReturnedVersionString|.
         * If the platform is macOS:
             1. Let |platformReturnedVersionString| be the result of querying the `NSProcessInfo` returned by `processInfo` and reading its `operatingSystemVersion`.


### PR DESCRIPTION
After investigation, the Linux uname API version string does not provide any developer-useful information. It is better to simply return the empty string.