### PR TITLE
Fixes #254 - Improve algorithms that take a "version type"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -490,10 +490,9 @@ The header's ABNF is:
 
 To <dfn abstract-op>return the `Sec-CH-UA` value for a request</dfn>, perform the following steps:
 
-1. Let |version type| be "significant version".
-1. Let |brands| be the result of running [=create brands=] with |version type|.
+1. Let |brands| be the result of running [=create brands=] with "significant version".
 1. Let |list| be the result of <a lt="create a brand-version list">creating a brand-version list</a>,
-    with |brands| and |version type|.
+    with |brands| and "significant version".
 1. Return the output of running [=serializing a list=] with |list|.
 
 Note: Unlike most Client Hints, since it's included in the [=low entropy hint table=],
@@ -666,11 +665,9 @@ The header's ABNF is:
 To <dfn abstract-op>return the `Sec-CH-UA-Full-Version-List` value for a request</dfn>, perform the
 following steps:
 
-1. Let |version type| be "full version".
-1. Let |brands| be the result of running [=create brands=] with |version type|.
-1. Let |list| be the result of
-    <a lt="create a brand-version list">creating a brand-version list</a>, with |brands| and
-    |version type|.
+1. Let |brands| be the result of running [=create brands=] with "full version".
+1. Let |list| be the result of [=creating a brand-version list|create a brand-version list=], with
+    |brands| and "full version".
 1. Return the output of running [=serializing a list=] with |list| as input.
 
 Note: These client hints can be evoked with the following set of [=client hints tokens=]:
@@ -749,13 +746,14 @@ the result of [=create a frozen array|creating a frozen array=] from running [=c
 When asked to <dfn>create brands</dfn> with |version type|, run the following steps:
 
 1. Let |list| be a [=/list=].
+1. [=Assert=] |version type| is either "full version" or "significant version".
 1. For each [=user agent/brand=] that represents the [=user agent=]—or an [=equivalence class=]—as
     |brand|:
-    1. Let |version| be a [=/string=].
-    1. If |version type| is "full version", set |version| to a string that corresponds to the
-        [=user agent/full version=].
-    1. If |version type| is "significant version", set |version| to a string that corresponds to the
-        [=user agent/significant version=].
+    1. Let |version| be a [=/string=], initialized accordingly:
+        1. If |version type| is "full version", set |version| to a string that corresponds to the
+            [=user agent/full version=].
+        1. If |version type| is "significant version", set |version| to a string that corresponds to
+            the [=user agent/significant version=].
     1. Let |dict| be a new {{NavigatorUABrandVersion}} dictionary, with
         {{NavigatorUABrandVersion/brand}} set to |brand| and
         {{NavigatorUABrandVersion/version}} set to |version|.
@@ -805,11 +803,12 @@ To <dfn>create an arbitrary brand</dfn>, the [=user agent=] MUST run these steps
           these are known to not be web-compatible.
 
 To <dfn>create an arbitrary version</dfn> given |version type|, run the following steps:
-    1. Let |arbitrary version| be a [=/string=].
-    1. If |version type| is "full version", set |arbitrary version| to a string that matches the
-        format of the [=user agent/full version=], but not the value.
-    1. If |version type| is "significant version", set |arbitrary version| to a string that matches
-        the format of [=user agent/significant version=], but not the value.
+    1. [=Assert=] |version type| is either "full version" or "significant version".
+    1. Let |arbitrary version| be a [=/string=], initialized accordingly:
+        1. If |version type| is "full version", set |arbitrary version| to a string that matches the
+            format of the [=user agent/full version=], but not the value.
+        1. If |version type| is "significant version", set |arbitrary version| to a string that
+            matches the format of [=user agent/significant version=], but not the value.
     1. Return |arbitrary version|.
 
 Note: User Agents may decide to send arbitrarily low versions to ensure proper version checking, and should vary them
@@ -822,12 +821,13 @@ To <dfn>create a brand-version list</dfn> given |brands| and |version type|, per
 steps:
 
     1. Let |list| be a [=/list=], initially empty.
+    1. [=Assert=] |version type| is either "full version" or "significant version".
     1. For each |brand| in |brands|:
-        1. Let |version| be a string.
-        1. If |version type| is "full version", set |version| to a string that corresponds to the
-        [=user agent/full version=].
-        1. If |version type| is "significant version", set |version| to a string that corresponds to
-        the [=user agent/significant version=].
+        1. Let |version| be a string, initialized accordingly:
+            1. If |version type| is "full version", set |version| to a string that corresponds to
+                the [=user agent/full version=].
+            1. If |version type| is "significant version", set |version| to a string that
+                corresponds to the [=user agent/significant version=].
         1. Let |parameter| be a [=dictionary=], initially empty.
         1. Set |parameter|["param_key"] to "v".
         1. Set |parameter|["param_value"] to |version|.

--- a/index.bs
+++ b/index.bs
@@ -490,7 +490,7 @@ The header's ABNF is:
 
 To <dfn abstract-op>return the `Sec-CH-UA` value for a request</dfn>, perform the following steps:
 
-1. Let |version type| be the type [=user agent/significant version=].
+1. Let |version type| be "significant version".
 1. Let |brands| be the result of running [=create brands=] with |version type|.
 1. Let |list| be the result of <a lt="create a brand-version list">creating a brand-version list</a>,
     with |brands| and |version type|.
@@ -666,7 +666,7 @@ The header's ABNF is:
 To <dfn abstract-op>return the `Sec-CH-UA-Full-Version-List` value for a request</dfn>, perform the
 following steps:
 
-1. Let |version type| be the type [=user agent/full version=].
+1. Let |version type| be "full version".
 1. Let |brands| be the result of running [=create brands=] with |version type|.
 1. Let |list| be the result of
     <a lt="create a brand-version list">creating a brand-version list</a>, with |brands| and
@@ -749,19 +749,23 @@ the result of [=create a frozen array|creating a frozen array=] from running [=c
 When asked to <dfn>create brands</dfn> with |version type|, run the following steps:
 
 1. Let |list| be a [=/list=].
-1. Collect pairs of [=user agent/brand=] and versions of type |version type| which represent the
-    [=user agent=] or [=equivalence classes=].
-1. For each pair:
-    1. Let |dict| be a new {{NavigatorUABrandVersion}} dictionary, with [=user agent/brand=] as
-        {{NavigatorUABrandVersion/brand}} and a string of type |version type| as
-        {{NavigatorUABrandVersion/version}}.
+1. For each [=user agent/brand=] that represents the [=user agent=]—or an [=equivalence class=]—as
+    |brand|:
+    1. Let |version| be a [=/string=].
+    1. If |version type| is "full version", set |version| to a string that corresponds to the
+        [=user agent/full version=].
+    1. If |version type| is "significant version", set |version| to a string that corresponds to the
+        [=user agent/significant version=].
+    1. Let |dict| be a new {{NavigatorUABrandVersion}} dictionary, with
+        {{NavigatorUABrandVersion/brand}} set to |brand| and
+        {{NavigatorUABrandVersion/version}} set to |version|.
     1. Append |dict| to |list|.
 1.  The [=user agent=] SHOULD execute the following steps:
     1. [=list/Append=] one additional [=list/item=] to |list| containing a
-        {{NavigatorUABrandVersion}} dictionary, initialized with
-        <a lt="create an arbitrary brand">arbitrary brand</a> as {{NavigatorUABrandVersion/brand}}
-        and the result of <a lt="create an arbitrary version">creating an arbitrary version</a> with
-        {{NavigatorUABrandVersion/version}}.
+        {{NavigatorUABrandVersion}} dictionary, initialized with {{NavigatorUABrandVersion/brand}}
+        set to <a lt="create an arbitrary brand">arbitrary brand</a> and set
+        {{NavigatorUABrandVersion/version}} to the result of
+        [=creating an arbitrary version|create an arbitrary version=] with |version type|.
     1.  Randomize the order of the [=list/items=] in |list|.
 
     Note: One approach to minimize caching variance when generating these random components could be to
@@ -802,11 +806,10 @@ To <dfn>create an arbitrary brand</dfn>, the [=user agent=] MUST run these steps
 
 To <dfn>create an arbitrary version</dfn> given |version type|, run the following steps:
     1. Let |arbitrary version| be a [=/string=].
-    1. If |version type| is [=user agent/significant version=], set |arbitrary version| to a string
-        that matches the format of the [=user agent=]'s [=user agent/significant version=], but not
-        the value.
-    1. If |version type| is [=user agent/full version=], set |arbitrary version| to to a string that
-        matches the format of the [=user agent=]'s [=user agent/full version=], but not the value.
+    1. If |version type| is "full version", set |arbitrary version| to a string that matches the
+        format of the [=user agent/full version=], but not the value.
+    1. If |version type| is "significant version", set |arbitrary version| to a string that matches
+        the format of [=user agent/significant version=], but not the value.
     1. Return |arbitrary version|.
 
 Note: User Agents may decide to send arbitrarily low versions to ensure proper version checking, and should vary them
@@ -820,10 +823,14 @@ steps:
 
     1. Let |list| be a [=/list=], initially empty.
     1. For each |brand| in |brands|:
+        1. Let |version| be a string.
+        1. If |version type| is "full version", set |version| to a string that corresponds to the
+        [=user agent/full version=].
+        1. If |version type| is "significant version", set |version| to a string that corresponds to
+        the [=user agent/significant version=].
         1. Let |parameter| be a [=dictionary=], initially empty.
         1. Set |parameter|["param_key"] to "v".
-        1. Set |parameter|["param_value"] to a string of type |version type| that corresponds
-            to |brand|.
+        1. Set |parameter|["param_value"] to |version|.
         1. Let |pair| be a tuple comprised of |brand|'s {{NavigatorUABrandVersion/brand}} and
             |parameter|.
         1. Append |pair| to |list|.


### PR DESCRIPTION
PTAL @yoavweiss


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Sep 21, 2021, 9:11 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2FWICG%2Fua-client-hints%2Fcfb3c39b798fa3cd5b2742a7db8303ba57e8ecd2%2Findex.bs&md-warning=not%20ready)

```
Error running preprocessor, returned code: 2.
FATAL ERROR: Couldn't load MDN Spec Links data for this spec.
Expecting value: line 1 column 1 (char 0)
 ✘  Did not generate, due to fatal errors
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20WICG/ua-client-hints%23260.)._
</details>
