### PR TITLE
Issue #179 - Add a size restriction to a brand name

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -429,7 +429,8 @@ defined in [[!RFC8942]]. The definitions below assume that each [=user agent=]
 has defined a number of properties for itself:
 
 *   <dfn for="user agent" export>brand</dfn> - The [=user agent=]'s commercial name (e.g.,
-      "cURL", "Edge", "The World's Best Web Browser")
+      "cURL", "Edge", "The World's Best Web Browser"), which MUST be shorter than 32 [=ASCII alpha=]
+      characters.
 *   <dfn for="user agent" export>significant version</dfn> - The marketing version which includes
       distinguishable web-exposed features (e.g., "72", "3", or "12.1"), corresponding to the
       [=user agent=], or any of the brands in its [=brands=] list (e.g., rendering engine or


### PR DESCRIPTION
edit: the idea here is to add some guidance so we don't end up with super large brand names in `Sec-CH-UA` (since it's a default low-entropy hint). But it's fairly arbitrary.

PTAL @yoavweiss 
If we want to restrict client hint tokens size, that's probably better in the infra spec.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/miketaylr/ua-client-hints/pull/270.html" title="Last updated on Oct 25, 2021, 7:24 PM UTC (5d51190)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/ua-client-hints/270/6f090a7...miketaylr:5d51190.html" title="Last updated on Oct 25, 2021, 7:24 PM UTC (5d51190)">Diff</a>