### PR TITLE
Issue #271 - Mark the Intro and Sections 1.1 and 1.2 as non-normative

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -86,6 +86,8 @@ urlPrefix: https://w3c.github.io/fingerprinting-guidance/
 Introduction {#intro}
 ============
 
+*This section is non-normative*.
+
 Today, user agents generally identify themselves to servers by sending a `User-Agent` HTTP request
 header field along with each request (defined in Section 5.5.3 of [[RFC7231]]). Ideally, this header
 would give servers the ability to perform content negotiation, sending down exactly those bits that
@@ -147,6 +149,8 @@ in [[FINGERPRINTING-GUIDANCE]]).
 Examples {#examples}
 --------
 
+*This section is non-normative*.
+
 A user navigates to `https://example.com/` for the first time using the latest version of the
 "Examplary Browser". Their user agent sends the following headers along with the HTTP request:
 
@@ -174,6 +178,8 @@ In response, the user agent includes the platform version information in the nex
 ```
 
 ## Use Cases ## {#use-cases}
+
+*This section is non-normative*.
 
 This section attempts to document the current uses for the `User-Agent` string,
 and how similar functionality could be enabled using User-Agent Client Hints (UA-CH).


### PR DESCRIPTION
Fixes #271

PTAL @amtunlimited


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/miketaylr/ua-client-hints/pull/272.html" title="Last updated on Nov 2, 2021, 2:24 PM UTC (8b353a5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/ua-client-hints/272/ab31750...miketaylr:8b353a5.html" title="Last updated on Nov 2, 2021, 2:24 PM UTC (8b353a5)">Diff</a>