### PR TITLE
Fixes #217 - Add a WoW64 boolean hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ a corresponding JavaScript API:
 * `Sec-CH-UA`
 * `Sec-CH-UA-Full-Version` (deprecated in favor of `Sec-CH-UA-Full-Version-List`)
 * `Sec-CH-UA-Full-Version-List`
+* `Sec-CH-UA-WoW64`
 
 
 ## Contributing
@@ -63,6 +64,7 @@ and pull requests. Before getting started, please read our
   - [How does `Sec-CH-UA-Mobile` define "mobile"?](#how-does-sec-ch-ua-mobile-define-mobile)
   - [Aren’t we duplicating a lot of information already in the `User-Agent` header?](#arent-we-duplicating-a-lot-of-information-already-in-the-user-agent-header)
   - [Aren’t you adding a lot of new headers? Isn’t that going to bloat requests?](#arent-you-adding-a-lot-of-new-headers-isnt-that-going-to-bloat-requests)
+  - [Why does a WoW64 hint exist?](#why-does-a-wow64-hint-exist)
 - [Considered alternatives](#considered-alternatives)
   - [Freezing the UA string and reducing its information density without providing an alternative mechanism](#freezing-the-ua-string-and-reducing-its-information-density-without-providing-an-alternative-mechanism)
   - [Restructuring of the User-Agent string](#restructuring-of-the-user-agent-string)
@@ -738,6 +740,10 @@ these requests. It’s also useful to keep in mind that by default User-Agent Cl
 sent to top-level origins by default—explicit delegation is required to send them to third-party
 origins or embedded frames. We feel the privacy wins and moving away from `User-Agent`’s legacy are
 a worthwhile tradeoff here, at the expense of adding some new headers to requests.
+
+## Why does a WoW64 hint exist?
+
+[WoW64](https://en.wikipedia.org/wiki/WoW64) indicates that a 32-bit User-Agent application is running on a 64-bit Windows machine. It was commonly used to know which NPAPI plugin installer should be offered for download. It's included here for backwards compatibility considerations, to provide a one to one mapping from the UA string of certain browsers to UA-CH. Note that not all browsers today have exposed this, and it may not always return a useful value.
 
 # Considered alternatives
 ## Freezing the UA string and reducing its information density without providing an alternative mechanism

--- a/index.bs
+++ b/index.bs
@@ -458,6 +458,7 @@ has defined a number of properties for itself:
       "Pixel 2 XL")
 *   <dfn for="user agent" export>mobileness</dfn> - A boolean indicating if the [=user agent=]'s
       device is a mobile device. (e.g., ?0 or ?1)
+*   <dfn for="user agent" export>wow64-ness</dfn> - A boolean indicating if the [=user agent=]'s binary is running in 32-bit mode on 64-bit Windows. (e.g., ?0 or ?1)
 
 
 [=User agents=] SHOULD keep these strings short and to the point, but servers MUST accept arbitrary
@@ -481,8 +482,9 @@ or [=platform bitness=] unless the user's platform is one where both the followi
 Agents=] MUST return the empty string for [=model=] even if [=mobileness=] is true, except on
 platforms where the model is typically exposed.
 
-[=User agents=] MAY return the empty string or a fictitious value for [=full version=], [=platform
-architecture=], [=platform bitness=] or [=model=], for privacy, compatibility, or other reasons.
+[=User agents=] MAY return the empty string for hints of type `sf-string`,
+`false` for hints of type `sf-boolean`, or any other fictitious value, for
+privacy, compatibility, or other reasons, given a request for any the following hints: [=full version=], [=platform architecture=], [=platform bitness=], [=wow64-ness=] or [=model=].
 
 The 'Sec-CH-UA' Header Field {#sec-ch-ua}
 ----------------------------
@@ -681,9 +683,22 @@ The header's ABNF is:
   Sec-CH-UA-Platform-Version = sf-string
 ```
 
+The 'Sec-CH-UA-WoW64' Header Field {#sec-ch-ua-wow64}
+--------------------------------
+
+The <dfn http-header>`Sec-CH-UA-WoW64`</dfn> request header field gives a server information about
+whether or not a [=user agent=] binary is running in 32-bit mode on 64-bit Windows.
+It is a [=Structured Header=] whose value MUST be a [=structured header/boolean=] [[!RFC8941]].
+
+The header's ABNF is:
+
+``` abnf
+  Sec-CH-UA-WoW64 = sf-boolean
+```
+
 Note: These client hints can be evoked with the following set of [=client hints tokens=]:
 `Sec-CH-UA`, `Sec-CH-UA-Arch`, `Sec-CH-UA-Bitness`, `Sec-CH-UA-Full-Version`, `Sec-CH-UA-Mobile`,
-`Sec-CH-UA-Model`, `Sec-CH-UA-Platform`, `Sec-CH-UA-Platform-Version`, `Sec-CH-UA-Full-Version-List`
+`Sec-CH-UA-Model`, `Sec-CH-UA-Platform`, `Sec-CH-UA-Platform-Version`, `Sec-CH-UA-WoW64`, `Sec-CH-UA-Full-Version-List`
 
 Interface {#interface}
 =================
@@ -703,6 +718,7 @@ dictionary UADataValues {
   DOMString platform;
   DOMString platformVersion;
   DOMString uaFullVersion; // deprecated in favor of fullVersionList
+  boolean wow64;
   sequence&lt;NavigatorUABrandVersion&gt; fullVersionList;
 };
 
@@ -881,7 +897,8 @@ ISSUE(wicg/ua-client-hints): We can improve upon when and why a UA decides to re
     1. If |hints| [=list/contains=] "platformVersion", set |uaData|["{{UADataValues/platformVersion}}"]
         to the [=user agent=]'s [=user agent/platform version=].
     1. If |hints| [=list/contains=] "uaFullVersion", set |uaData|["{{UADataValues/uaFullVersion}}"]
-        to the user agent's [=user agent/full version=].
+    1. If |hints| [=list/contains=] "wow64", set |uaData|["{{UADataValues/wow64}}"]
+        to the user agent's [=user agent/wow64-ness=].
     1. If |hints| [=list/contains=] "fullVersionList", set |uaData|["{{UADataValues/fullVersionList}}"]
         to [=this=]'s [=relevant global object=]'s
         [=WindowOrWorkerGlobalScope/full version list frozen array=].
@@ -1033,7 +1050,7 @@ IANA Considerations {#iana}
 
 This document intends to define the `Sec-CH-UA`, `Sec-CH-UA-Arch`, `Sec-CH-UA-Bitness`,
 `Sec-CH-UA-Full-Version`, `Sec-CH-UA-Mobile`, `Sec-CH-UA-Model`, `Sec-CH-UA-Platform`,
-`Sec-CH-UA-Platform-Version`, and the `Sec-CH-UA-Full-Version-List` HTTP request header fields, and
+`Sec-CH-UA-Platform-Version`, `Sec-CH-UA-WoW64`, and the `Sec-CH-UA-Full-Version-List` HTTP request header fields, and
 register them in the permanent message header field registry ([[RFC3864]]).
 
 It also intends to deprecate usage of the `User-Agent` header field.
@@ -1142,6 +1159,19 @@ Author/Change controller: IETF
 
 Specification document: this specification ([[#sec-ch-ua-platform-version]])
 
+'Sec-CH-UA-WoW64' Header Field {#iana-wow64}
+-------------------------
+
+Header field name: Sec-CH-UA-WoW64
+
+Applicable protocol: http
+
+Status: standard
+
+Author/Change controller: IETF
+
+Specification document: this specification ([[#sec-ch-ua-wow64]])
+
 'Sec-CH-UA-Full-Version-List' Header Field {#iana-full-version-list}
 -------------------------
 
@@ -1173,6 +1203,7 @@ Acknowledgments {#ack}
 
 Thanks to
 Aaron Tagliaboschi,
+Ali Beyad,
 ArkUmbra, <!-- github -->
 Erik Anderson,
 jasonwee, <!-- github -->

--- a/index.bs
+++ b/index.bs
@@ -559,6 +559,27 @@ The header's ABNF is:
   Sec-CH-UA-Full-Version = sf-string
 ```
 
+The 'Sec-CH-UA-Full-Version-List' Header Field {#sec-ch-ua-full-version-list}
+--------------------------------
+
+The <dfn http-header>`Sec-CH-UA-Full-Version-List`</dfn> request header field gives a server
+information about the [=user agent/full version=] for each brand in its [=brands=] list. It is a
+[=Structured Header=] whose value MUST be a [=structured header/list=] [[!RFC8941]].
+
+The header's ABNF is:
+
+``` abnf
+  Sec-CH-UA-Full-Version-List = sf-list
+```
+
+To <dfn abstract-op>return the `Sec-CH-UA-Full-Version-List` value for a request</dfn>, perform the
+following steps:
+
+1. Let |brands| be the result of running [=create brands=] with "full version".
+1. Let |list| be the result of [=creating a brand-version list|create a brand-version list=], with
+    |brands| and "full version".
+1. Return the output of running [=serializing a list=] with |list| as input.
+
 The 'Sec-CH-UA-Mobile' Header Field {#sec-ch-ua-mobile}
 --------------------------------
 
@@ -659,27 +680,6 @@ The header's ABNF is:
 ``` abnf
   Sec-CH-UA-Platform-Version = sf-string
 ```
-
-The 'Sec-CH-UA-Full-Version-List' Header Field {#sec-ch-ua-full-version-list}
---------------------------------
-
-The <dfn http-header>`Sec-CH-UA-Full-Version-List`</dfn> request header field gives a server
-information about the [=user agent/full version=] for each brand in its [=brands=] list. It is a
-[=Structured Header=] whose value MUST be a [=structured header/list=] [[!RFC8941]].
-
-The header's ABNF is:
-
-``` abnf
-  Sec-CH-UA-Full-Version-List = sf-list
-```
-
-To <dfn abstract-op>return the `Sec-CH-UA-Full-Version-List` value for a request</dfn>, perform the
-following steps:
-
-1. Let |brands| be the result of running [=create brands=] with "full version".
-1. Let |list| be the result of [=creating a brand-version list|create a brand-version list=], with
-    |brands| and "full version".
-1. Return the output of running [=serializing a list=] with |list| as input.
 
 Note: These client hints can be evoked with the following set of [=client hints tokens=]:
 `Sec-CH-UA`, `Sec-CH-UA-Arch`, `Sec-CH-UA-Bitness`, `Sec-CH-UA-Full-Version`, `Sec-CH-UA-Mobile`,

--- a/index.bs
+++ b/index.bs
@@ -697,8 +697,9 @@ The header's ABNF is:
 ```
 
 Note: These client hints can be evoked with the following set of [=client hints tokens=]:
-`Sec-CH-UA`, `Sec-CH-UA-Arch`, `Sec-CH-UA-Bitness`, `Sec-CH-UA-Full-Version`, `Sec-CH-UA-Mobile`,
-`Sec-CH-UA-Model`, `Sec-CH-UA-Platform`, `Sec-CH-UA-Platform-Version`, `Sec-CH-UA-WoW64`, `Sec-CH-UA-Full-Version-List`
+`Sec-CH-UA`, `Sec-CH-UA-Arch`, `Sec-CH-UA-Bitness`, `Sec-CH-UA-Full-Version`,
+`Sec-CH-UA-Full-Version-List`, `Sec-CH-UA-Mobile`, `Sec-CH-UA-Model`, `Sec-CH-UA-Platform`,
+`Sec-CH-UA-Platform-Version`, `Sec-CH-UA-WoW64`
 
 Interface {#interface}
 =================
@@ -892,6 +893,9 @@ ISSUE(wicg/ua-client-hints): We can improve upon when and why a UA decides to re
         the [=user agent=]'s [=user agent/platform architecture=].
     1. If |hints| [=list/contains=] "bitness", set |uaData|["{{UADataValues/bitness}}"] to
         the [=user agent=]'s [=user agent/platform bitness=].
+    1. If |hints| [=list/contains=] "fullVersionList", set |uaData|["{{UADataValues/fullVersionList}}"]
+        to [=this=]'s [=relevant global object=]'s
+        [=WindowOrWorkerGlobalScope/full version list frozen array=].
     1. If |hints| [=list/contains=] "model", set |uaData|["{{UADataValues/model}}"] to the
         [=user agent=]'s [=user agent/model=].
     1. If |hints| [=list/contains=] "platformVersion", set |uaData|["{{UADataValues/platformVersion}}"]
@@ -899,9 +903,6 @@ ISSUE(wicg/ua-client-hints): We can improve upon when and why a UA decides to re
     1. If |hints| [=list/contains=] "uaFullVersion", set |uaData|["{{UADataValues/uaFullVersion}}"]
     1. If |hints| [=list/contains=] "wow64", set |uaData|["{{UADataValues/wow64}}"]
         to the user agent's [=user agent/wow64-ness=].
-    1. If |hints| [=list/contains=] "fullVersionList", set |uaData|["{{UADataValues/fullVersionList}}"]
-        to [=this=]'s [=relevant global object=]'s
-        [=WindowOrWorkerGlobalScope/full version list frozen array=].
     1. [=Queue a task=] on the [=permission task source=] to [=resolve=] |p| with |uaData|.
 
 4.  Return |p|.
@@ -1050,8 +1051,8 @@ IANA Considerations {#iana}
 
 This document intends to define the `Sec-CH-UA`, `Sec-CH-UA-Arch`, `Sec-CH-UA-Bitness`,
 `Sec-CH-UA-Full-Version`, `Sec-CH-UA-Mobile`, `Sec-CH-UA-Model`, `Sec-CH-UA-Platform`,
-`Sec-CH-UA-Platform-Version`, `Sec-CH-UA-WoW64`, and the `Sec-CH-UA-Full-Version-List` HTTP request header fields, and
-register them in the permanent message header field registry ([[RFC3864]]).
+`Sec-CH-UA-Platform-Version`, `Sec-CH-UA-WoW64`, and the `Sec-CH-UA-Full-Version-List` HTTP request
+header fields, and register them in the permanent message header field registry ([[RFC3864]]).
 
 It also intends to deprecate usage of the `User-Agent` header field.
 
@@ -1106,6 +1107,19 @@ Status: deprecated
 Author/Change controller: IETF
 
 Specification document: this specification ([[#sec-ch-ua-full-version]])
+
+'Sec-CH-UA-Full-Version-List' Header Field {#iana-full-version-list}
+-------------------------
+
+Header field name: Sec-CH-UA-Full-Version-List
+
+Applicable protocol: http
+
+Status: standard
+
+Author/Change controller: IETF
+
+Specification document: this specification ([[#sec-ch-ua-full-version-list]])
 
 'Sec-CH-UA-Mobile' Header Field {#iana-mobile}
 ----------------------------
@@ -1171,19 +1185,6 @@ Status: standard
 Author/Change controller: IETF
 
 Specification document: this specification ([[#sec-ch-ua-wow64]])
-
-'Sec-CH-UA-Full-Version-List' Header Field {#iana-full-version-list}
--------------------------
-
-Header field name: Sec-CH-UA-Full-Version-List
-
-Applicable protocol: http
-
-Status: standard
-
-Author/Change controller: IETF
-
-Specification document: this specification ([[#sec-ch-ua-full-version-list]])
 
 'User-Agent' Header Field {#iana-user-agent}
 -------------------------


### PR DESCRIPTION
PTAL @yoavweiss - this is the last missing piece from the UA string in some browsers (Chromium, perhaps others). The idea is allow for a one to one mapping possible from UA to UA-CH.