### PR TITLE
Add Fuchsia to common values of Sec-CH-UA-Platform

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -621,8 +621,8 @@ The 'Sec-CH-UA-Platform' Header Field {#sec-ch-ua-platform}
 The <dfn http-header>`Sec-CH-UA-Platform`</dfn> request header field gives a server information
 about the platform on which a given [=user agent=] is executing. It is a [=Structured Header=]
 whose value MUST be a [=structured header/string=] [[!RFC8941]]. Its value SHOULD match one of the
-following common platform values: "Android", "Chrome OS", "iOS", "Linux", "macOS", "Windows", or
-"Unknown".
+following common platform values: "Android", "Chrome OS", "Fuchsia", "iOS", "Linux", "macOS",
+"Windows", or "Unknown".
 
 The header's ABNF is:
 


### PR DESCRIPTION
Chrome and WebEngine currently reports "Fuchsia" for Sec-CH-UA-Platform.
Based on suggestion from crbug.com/1225775#c15, we should add this to the spec.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wintermelons/ua-client-hints/pull/297.html" title="Last updated on Apr 4, 2022, 11:27 PM UTC (4eafc34)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/ua-client-hints/297/6ab12fa...wintermelons:4eafc34.html" title="Last updated on Apr 4, 2022, 11:27 PM UTC (4eafc34)">Diff</a>