### PR TITLE
"typically exposed" is hard to determine in a technical specification…

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -478,10 +478,6 @@ or [=platform bitness=] unless the user's platform is one where both the followi
  * Different CPU architectures are likely to require different binary executable resources, and
      different binary executable resources are likely to be available.
 
-[=User Agents=] MUST return the empty string for [=model=] if [=mobileness=] is false. [=User
-Agents=] MUST return the empty string for [=model=] even if [=mobileness=] is true, except on
-platforms where the model is typically exposed.
-
 [=User agents=] MAY return the empty string for hints of type `sf-string`,
 `false` for hints of type `sf-boolean`, or any other fictitious value, for
 privacy, compatibility, or other reasons, given a request for any the following hints:


### PR DESCRIPTION
… and needs to be removed.

Why shouldn't a user agent return information about the model associated with a device that does not also return true for the Mobile field? Google's own services display the model of Windows desktop or laptop device when providing information about login history for example.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jun 10, 2022, 10:24 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fjwrosewell%2Fua-client-hints%2F021bc1b2c87b509e00f2eb9fc3c55daea13ded8f%2Findex.bs&md-warning=not%20ready)

```
Error running preprocessor, returned code: 2.
FATAL ERROR: Obsolete biblio ref: [rfc7231] is replaced by [rfc9110]. Either update the reference, or use [rfc7231 obsolete] if this is an intentionally-obsolete reference.
 ✘  Did not generate, due to fatal errors
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20WICG/ua-client-hints%23305.)._
</details>
