### PR TITLE
Fixes #309 - Don't start or end a greaseyBrand w/ a greaseyChar

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -850,13 +850,15 @@ To <dfn>create an arbitrary brand</dfn>, the [=user agent=] MUST run these steps
     1. Let |greaseyStack| be a [=stack=].
     1. Let |greaseyChars| be the [=list=] of [=ASCII bytes=] « 0x20 (SP), 0x28 (left parenthesis), 0x29
          (right parenthesis), 0x2D (-), 0x2E (.), 0x2F (/), 0x3A (:), 0x3B (;), 0x3D (=), 0x3F (?), 0x5F (_) ».
-    1. For each item of |arbitraryBrandList|, [=stack/push=] a randomly selected [=list/item=] from |greaseyChars| onto
-         |greaseyStack|.
-    1. Let |greaseyBrandList| be a [=list=] and |index| be 0.
+    1. Let |index| be 0.
+    1. While |index| is less than the [=list/size=] of |arbitraryBrandList|:
+        1. [=stack/Push=] a randomly selected [=list/item=] from |greaseyChars| onto |greaseyStack|.
+        1. Increment |index| by 1.
+    1. Let |greaseyBrandList| be a [=list=] and set |index| to 0.
     1. While |greaseyStack| [=stack/is not empty=]:
-        1. Let |item| be the result of <a lt="pop">popping</a> from |greaseyStack|.
-        1. [=list/Append=] |item| to |greaseyBrandList|.
         1. [=list/Append=] |arbitraryBrandList|[|index|] to |greaseyBrandList|.
+        1. Let |item| be the result of [=popping=] from |greaseyStack|.
+        1. [=list/Append=] |item| to |greaseyBrandList|.
         1. Increment |index| by 1.
     1. Return the result of <a lt="strip leading and trailing ASCII whitespace"> stripping leading and trailing ASCII
          whitespace</a> from the [=concatenation=] of |greaseyBrandList| (with no separator).

--- a/index.bs
+++ b/index.bs
@@ -835,7 +835,7 @@ When asked to <dfn>create brands</dfn> with |version type|, run the following st
     Note: See [[#grease]] for more details on when and why these randomization steps might be appropriate.
 1. Return |list|.
 
-An <dfn for="user agent" export>equivalence class</dfn> represents a group of browsers believed to be compatibile with
+An <dfn for="user agent" export>equivalence class</dfn> represents a group of browsers believed to be compatible with
 each other. A shared rendering engine may form an [=equivalence class=], for example.
 
 <h4 id="create-arbitrary-brands-section"
@@ -867,7 +867,7 @@ To <dfn>create an arbitrary brand</dfn>, the [=user agent=] MUST run these steps
         separator).
 
     Note: This algorithm should result in an arbitrary brand without leading or trailing
-      |greaseyChars|, as implmentation experience has shown these are not web-compatibile.
+      |greaseyChars|, as implementation experience has shown these are not web-compatible.
 
 To <dfn>create an arbitrary version</dfn> given |version type|, run the following steps:
     1. [=Assert=] |version type| is either "full version" or "significant version".

--- a/index.bs
+++ b/index.bs
@@ -864,8 +864,8 @@ To <dfn>create an arbitrary brand</dfn>, the [=user agent=] MUST run these steps
     1. Return the result of <a lt="strip leading and trailing ASCII whitespace"> stripping leading and trailing ASCII
          whitespace</a> from the [=concatenation=] of |greaseyBrandList| (with no separator).
 
-    Note: [=Structured Headers=] allows for escaped 0x22 (\") and 0x5C (\\) inside a [=structured header/string=], but
-          these are known to not be web-compatible.
+    Note: This algorithm should result in an arbitrary brand without leading or trailing
+      |greaseyChars|, as implmentation experience has shown these are not web-compatibile.
 
 To <dfn>create an arbitrary version</dfn> given |version type|, run the following steps:
     1. [=Assert=] |version type| is either "full version" or "significant version".

--- a/index.bs
+++ b/index.bs
@@ -866,8 +866,15 @@ To <dfn>create an arbitrary brand</dfn>, the [=user agent=] MUST run these steps
         and trailing ASCII whitespace</a> from the [=concatenation=] of |greaseyBrandList| (with no
         separator).
 
-    Note: This algorithm should result in an arbitrary brand without leading or trailing
-      |greaseyChars|, as implementation experience has shown these are not web-compatible.
+<div class="note">
+This algorithm should result in an arbitrary brand without leading or trailing |greaseyChars|, as
+implementation experience has shown these are not web-compatible.
+
+In addition, despite
+[=Structured Headers=] allowing for escaped 0x22 (\") and 0x5C (\\) inside a
+[=structured header/string=], these characters have also created compatibility issues with
+firewalls.
+</div>
 
 To <dfn>create an arbitrary version</dfn> given |version type|, run the following steps:
     1. [=Assert=] |version type| is either "full version" or "significant version".

--- a/index.bs
+++ b/index.bs
@@ -851,7 +851,7 @@ To <dfn>create an arbitrary brand</dfn>, the [=user agent=] MUST run these steps
     1. Let |greaseyChars| be the [=list=] of [=ASCII bytes=] « 0x20 (SP), 0x28 (left parenthesis), 0x29
          (right parenthesis), 0x2D (-), 0x2E (.), 0x2F (/), 0x3A (:), 0x3B (;), 0x3D (=), 0x3F (?), 0x5F (_) ».
     1. Let |index| be 0.
-    1. While |index| is less than the [=list/size=] of |arbitraryBrandList|:
+    1. While |index| is less than the [=list/size=] of |arbitraryBrandList| minus one:
         1. [=stack/Push=] a randomly selected [=list/item=] from |greaseyChars| onto |greaseyStack|.
         1. Increment |index| by 1.
     1. Let |greaseyBrandList| be a [=list=] and set |index| to 0.
@@ -860,6 +860,7 @@ To <dfn>create an arbitrary brand</dfn>, the [=user agent=] MUST run these steps
         1. Let |item| be the result of [=popping=] from |greaseyStack|.
         1. [=list/Append=] |item| to |greaseyBrandList|.
         1. Increment |index| by 1.
+    1. [=list/Append=] |arbitraryBrandList|[|index|] to |greaseyBrandList|.
     1. Return the result of <a lt="strip leading and trailing ASCII whitespace"> stripping leading and trailing ASCII
          whitespace</a> from the [=concatenation=] of |greaseyBrandList| (with no separator).
 

--- a/index.bs
+++ b/index.bs
@@ -89,7 +89,7 @@ Introduction {#intro}
 *This section is non-normative*.
 
 Today, user agents generally identify themselves to servers by sending a `User-Agent` HTTP request
-header field along with each request (defined in Section 5.5.3 of [[RFC7231]]). Ideally, this header
+header field along with each request (defined in Section 5.5.3 of [[rfc9110]]). Ideally, this header
 would give servers the ability to perform content negotiation, sending down exactly those bits that
 best represent the requested resource in a given user agent, optimizing both bandwidth and user
 experience. In practice, however, this header's value exposes far more information about the user's
@@ -1238,7 +1238,7 @@ Status: deprecated
 
 Author/Change controller: IETF
 
-Specification document: this specification ([[#user-agent]]), and Section 5.5.3 of [[RFC7231]]
+Specification document: this specification ([[#user-agent]]), and Section 5.5.3 of [[rfc9110]]
 
 Acknowledgments {#ack}
 =============================

--- a/index.bs
+++ b/index.bs
@@ -843,13 +843,14 @@ each other. A shared rendering engine may form an [=equivalence class=], for exa
 
 To <dfn>create an arbitrary brand</dfn>, the [=user agent=] MUST run these steps:
 
-    1. Let |arbitraryBrand| be a [=/string=] composed of [=ASCII alpha=]. |arbitraryBrand| MUST contain one or more
-         0x20 (SP) bytes and be no longer than twenty [=ASCII bytes=].
-    1. Let |arbitraryBrandList| be the result of <a lt="split on ASCII whitespace">splitting |arbitraryBrand| on ASCII
-         whitespace</a>.
+    1. Let |arbitraryBrand| be a [=/string=] composed of [=ASCII alpha=]. |arbitraryBrand| MUST
+        contain one or more 0x20 (SP) bytes and be no longer than twenty [=ASCII bytes=].
+    1. Let |arbitraryBrandList| be the result of <a lt="split on ASCII whitespace">splitting
+        |arbitraryBrand| on ASCII whitespace</a>.
     1. Let |greaseyStack| be a [=stack=].
-    1. Let |greaseyChars| be the [=list=] of [=ASCII bytes=] « 0x20 (SP), 0x28 (left parenthesis), 0x29
-         (right parenthesis), 0x2D (-), 0x2E (.), 0x2F (/), 0x3A (:), 0x3B (;), 0x3D (=), 0x3F (?), 0x5F (_) ».
+    1. Let |greaseyChars| be the [=list=] of [=ASCII bytes=] « 0x20 (SP), 0x28 (left parenthesis),
+        0x29 (right parenthesis), 0x2D (-), 0x2E (.), 0x2F (/), 0x3A (:), 0x3B (;), 0x3D (=), 0x3F
+        (?), 0x5F (_) ».
     1. Let |index| be 0.
     1. While |index| is less than the [=list/size=] of |arbitraryBrandList| minus one:
         1. [=stack/Push=] a randomly selected [=list/item=] from |greaseyChars| onto |greaseyStack|.
@@ -861,8 +862,9 @@ To <dfn>create an arbitrary brand</dfn>, the [=user agent=] MUST run these steps
         1. [=list/Append=] |item| to |greaseyBrandList|.
         1. Increment |index| by 1.
     1. [=list/Append=] |arbitraryBrandList|[|index|] to |greaseyBrandList|.
-    1. Return the result of <a lt="strip leading and trailing ASCII whitespace"> stripping leading and trailing ASCII
-         whitespace</a> from the [=concatenation=] of |greaseyBrandList| (with no separator).
+    1. Return the result of <a lt="strip leading and trailing ASCII whitespace"> stripping leading
+        and trailing ASCII whitespace</a> from the [=concatenation=] of |greaseyBrandList| (with no
+        separator).
 
     Note: This algorithm should result in an arbitrary brand without leading or trailing
       |greaseyChars|, as implmentation experience has shown these are not web-compatibile.

--- a/index.bs
+++ b/index.bs
@@ -843,8 +843,9 @@ each other. A shared rendering engine may form an [=equivalence class=], for exa
 
 To <dfn>create an arbitrary brand</dfn>, the [=user agent=] MUST run these steps:
 
-    1. Let |arbitraryBrand| be a [=/string=] composed of [=ASCII alpha=]. |arbitraryBrand| MUST
-        contain one or more 0x20 (SP) bytes and be no longer than twenty [=ASCII bytes=].
+    1. Let |arbitraryBrand| be a [=/string=] composed of [=ASCII alpha=] and 0x20 (SP).
+        |arbitraryBrand| MUST contain one or more 0x20 (SP) bytes and be no longer than twenty
+        [=ASCII bytes=], and MUST not start or end with 0x20 (SP).
     1. Let |arbitraryBrandList| be the result of <a lt="split on ASCII whitespace">splitting
         |arbitraryBrand| on ASCII whitespace</a>.
     1. Let |greaseyStack| be a [=stack=].


### PR DESCRIPTION
Implementation experience has taught us that starting a brand w/
certain characters causes breakage (likely from firewalls). To
be conservative, we prevent starting or ending with those.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jun 28, 2022, 8:54 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2FWICG%2Fua-client-hints%2Ffb52ee6a9022d346d6a45d4fc6ab92a926951076%2Findex.bs&md-warning=not%20ready)

```
Error running preprocessor, returned code: 2.
FATAL ERROR: Obsolete biblio ref: [rfc7231] is replaced by [rfc9110]. Either update the reference, or use [rfc7231 obsolete] if this is an intentionally-obsolete reference.
 ✘  Did not generate, due to fatal errors
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20WICG/ua-client-hints%23310.)._
</details>
