### PR TITLE
Use "Automotive" instead of "Automobile"

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ accomplish this as follows:
       boolean mobile;             // true
       DOMString architecture;     // "arm"
       DOMString bitness;          // "64"
-      DOMString formFactor;       // "Automobile"
+      DOMString formFactor;       // "Automotive"
       FrozenArray<NavigatorUABrandVersion> fullVersionList; // [ {brand: "Google Chrome", version: "84.0.4147.0"}, {brand: "Chromium", version: "84.0.4147"} ]
       DOMString model;            // "X644GTM"
       DOMString platform;         // "PhoneOS"

--- a/index.bs
+++ b/index.bs
@@ -555,7 +555,7 @@ The 'Sec-CH-UA-Form-Factor' Header Field {#sec-ch-ua-form-factor}
 The <dfn http-header>`Sec-CH-UA-Form-Factor`</dfn> request header field gives a server information
 about the [=user agent=]'s [=form-factor=]. It is a [=Structured Header=] whose value MUST be a
 [=structured header/string=]. Its value SHOULD match one of the following common form-factor values:
-"Automobile", "Mobile", "Tablet", "TV", "VR", "XR", "Unknown" or the empty string.
+"Automotive", "Mobile", "Tablet", "TV", "VR", "XR", "Unknown" or the empty string.
 [[!RFC8941]].
 
 Note: A "desktop" form-factor would be represented by the empty string.


### PR DESCRIPTION
This has the advantage of not match against poorly written regular expressions that are looking for "mobile" (probably not a real risk, but might as well change it before it becomes a problem).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/miketaylr/ua-client-hints/pull/339.html" title="Last updated on Apr 1, 2023, 11:21 PM UTC (5b41d06)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/ua-client-hints/339/e24995c...miketaylr:5b41d06.html" title="Last updated on Apr 1, 2023, 11:21 PM UTC (5b41d06)">Diff</a>