### PR TITLE
Make Sec-CH-UA-Form-Factor a list, add meanings

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -560,7 +560,8 @@ one or more of the following common form-factor values: "Desktop",
 "Automotive", "Mobile", "Tablet", "TV", "VR", or "XR". Order of the values
 in the list is not significant.
 
-Note: The form-factor of a device describes how the user interacts with the
+<div class="note" heading="">
+The form-factor of a device describes how the user interacts with the
 device.
  * "Desktop" refers to a user-agent running on a personal computer.
  * "Automotive" refers to a user-agent embedded in a vehicle, where the user
@@ -574,6 +575,7 @@ device.
  * "VR" refers to an immersive, gesture-oriented device.
  * "XR" is similar to "VR"  but includes devices that integrate with the
     environment around the user.
+</div>
 
 The header's ABNF is:
 

--- a/index.bs
+++ b/index.bs
@@ -575,6 +575,7 @@ device.
  * "VR" refers to an immersive, gesture-oriented device.
  * "XR" is similar to "VR"  but includes devices that integrate with the
     environment around the user.
+
 </div>
 
 The header's ABNF is:

--- a/index.bs
+++ b/index.bs
@@ -552,18 +552,33 @@ The header's ABNF is:
 The 'Sec-CH-UA-Form-Factor' Header Field {#sec-ch-ua-form-factor}
 ------------------------------
 
-The <dfn http-header>`Sec-CH-UA-Form-Factor`</dfn> request header field gives a server information
-about the [=user agent=]'s [=form-factor=]. It is a [=Structured Header=] whose value MUST be a
-[=structured header/string=]. Its value SHOULD match one of the following common form-factor values:
-"Automotive", "Mobile", "Tablet", "TV", "VR", "XR", "Unknown" or the empty string.
-[[!RFC8941]].
+The <dfn http-header>`Sec-CH-UA-Form-Factor`</dfn> request header field gives a
+server information about the [=user agent=]'s [=form-factor=]. It is a
+[=Structured Header=] whose value MUST be a [=structured header/list=]
+[[!RFC8941]]. Its values SHOULD describe the form-factor of the device using
+one or more of the following common form-factor values: "Desktop",
+"Automotive", "Mobile", "Tablet", "TV", "VR", or "XR". Order of the values
+in the list is not significant.
 
-Note: A "desktop" form-factor would be represented by the empty string.
+Note: The form-factor of a device describes how the user interacts with the
+device.
+ * "Desktop" refers to a user-agent running on a personal computer.
+ * "Automotive" refers to a user-agent embedded in a vehicle, where the user
+    may be responsible for operating the vehicle and unable to attend to small
+    details.
+ * "Mobile" refers to small, touch-oriented device typically carried on a
+    user's person.
+ * "Tablet" refers to a touch-oriented device larger than "Mobile" and not
+    typically carried on a user's person.
+ * "TV" refers to a large, multi-user device desiged primarily for viewing videos.
+ * "VR" refers to an immersive, gesture-oriented device.
+ * "XR" is similar to "VR"  but includes devices that integrate with the
+    environment around the user.
 
 The header's ABNF is:
 
 ~~~ abnf
-  Sec-CH-UA-Form-Factor = sf-string
+  Sec-CH-UA-Form-Factor = sf-list
 ~~~
 
 The 'Sec-CH-UA-Full-Version' Header Field {#sec-ch-ua-full-version}

--- a/index.bs
+++ b/index.bs
@@ -555,14 +555,17 @@ The 'Sec-CH-UA-Form-Factor' Header Field {#sec-ch-ua-form-factor}
 The <dfn http-header>`Sec-CH-UA-Form-Factor`</dfn> request header field gives a
 server information about the [=user agent=]'s [=form-factor=]. It is a
 [=Structured Header=] whose value MUST be a [=structured header/list=]
-[[!RFC8941]]. Its values SHOULD describe the form-factor of the device using
-one or more of the following common form-factor values: "Desktop",
-"Automotive", "Mobile", "Tablet", "TV", "VR", or "XR". Order of the values
-in the list is not significant.
+[[!RFC8941]]. The header's values MUST be given in lexical order.
+
+The header SHOULD describe the form-factor of the device using one or more of
+the following common form-factor values: "Desktop", "Automotive", "Mobile",
+"Tablet", or "XR". All applicable form-factor values SHOULD be included.
 
 <div class="note" heading="">
-The form-factor of a device describes how the user interacts with the
-device.
+
+The form-factor of a user-agent describes how the user interacts with the
+user-agent. The meanings of the allowed values are:
+
  * "Desktop" refers to a user-agent running on a personal computer.
  * "Automotive" refers to a user-agent embedded in a vehicle, where the user
     may be responsible for operating the vehicle and unable to attend to small
@@ -571,10 +574,14 @@ device.
     user's person.
  * "Tablet" refers to a touch-oriented device larger than "Mobile" and not
     typically carried on a user's person.
- * "TV" refers to a large, multi-user device desiged primarily for viewing videos.
- * "VR" refers to an immersive, gesture-oriented device.
- * "XR" is similar to "VR"  but includes devices that integrate with the
-    environment around the user.
+ * "XR" refers to immersive devices that augment or replace the environment
+    around the user.
+
+A new value should be proposed and added to the specification when there is a
+new form-factor that users interact with in a meaningfully different way; a
+compelling use-case where sites would like to change how they interact with
+users on that device; and no reliable way to identify that new form-factor
+using existing hints.
 
 </div>
 


### PR DESCRIPTION
This
* Makes the hint a set (in the form of a sorted list)
* enumerates the allowed values with non-normative descriptions
* adds some non-normative language about adding values


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/djmitche/ua-client-hints/pull/343.html" title="Last updated on Aug 24, 2023, 4:10 PM UTC (27cf93c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/ua-client-hints/343/d937348...djmitche:27cf93c.html" title="Last updated on Aug 24, 2023, 4:10 PM UTC (27cf93c)">Diff</a>