### PR TITLE
Editorial: correct header name in an example

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -347,8 +347,8 @@ depends on a few factors: their operating system, its version, its bitness, as w
 architecture.
 
 In order to tackle that use case, download sites can opt-in to receive the `Sec-CH-UA-Platform`,
-`Sec-CH-UA-Platform-Version`, `Sec-CH-UA-Architecture`, and `Sec-CH-UA-Bitness` hints (or query
-them through the API), in order to ensure the right binary is offered to the user by default.
+`Sec-CH-UA-Platform-Version`, `Sec-CH-UA-Arch`, and `Sec-CH-UA-Bitness` hints (or query them through
+the API), in order to ensure the right binary is offered to the user by default.
 
 ### Conversion modeling ### {#conversion-modeling-use-case}
 Some machine learning models use various details from the `User-Agent` string in order to estimate


### PR DESCRIPTION
Example incorrectly called header Sec-CH-UA-Architecture, while it should be Sec-CH-UA-Arch.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bershanskiy/ua-client-hints/pull/380.html" title="Last updated on May 9, 2025, 7:23 PM UTC (7dd1218)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/ua-client-hints/380/d7717ea...bershanskiy:7dd1218.html" title="Last updated on May 9, 2025, 7:23 PM UTC (7dd1218)">Diff</a>