### PR TITLE
Change Fuchsia to return empty platform version

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -698,7 +698,7 @@ It is a [=Structured Header=] whose value MUST be a [=structured header/string=]
 value is the result of [=getting the platform version=] with [=user agent/platform brand=].
 
 To <dfn>get the platform version</dfn>, given a string |platform|, run the following steps:
-    1. If |platform| is "Linux":
+    1. If |platform| is either "Linux" or "Fuchsia":
         1. Return the empty string.
     1. If |platform| is "Android":
         1. Let |platformReturnedVersionString| be the result of querying the OS's


### PR DESCRIPTION
Fuchsia currently reports 0.0.0


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wintermelons/ua-client-hints/pull/382.html" title="Last updated on Nov 5, 2025, 12:13 AM UTC (33e517d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/ua-client-hints/382/2280820...wintermelons:33e517d.html" title="Last updated on Nov 5, 2025, 12:13 AM UTC (33e517d)">Diff</a>