### PR TITLE
fix header link

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1084,7 +1084,8 @@ A [=User agent=] has <dfn>emulated client hints</dfn>, which is a [=struct=] wit
 * [=struct/item=] named <dfn for="emulated client hints" export>emulated client hints per navigables</dfn>,
     which is a weak map between [=/navigables=] and [=user agent client hints=], initially empty.
 
-## The emulation.setClientHintsOverride command {#emulation-setclienthintsoverride}
+The emulation.setClientHintsOverride command {#emulation-setclienthintsoverride}
+----------------
 
 The <dfn export for=commands>emulation.setClientHintsOverride</dfn> command sets or removes
 emulated user agent client hints for a list of [=/navigables=] or [=user context=], or globally.


### PR DESCRIPTION
Apparently the header incorrectly used the anchor syntax. Tested locally.