### PR TITLE
`emulation.setClientHintsOverride` -> `userAgentClientHints.setClientHintsOverride`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1048,7 +1048,7 @@ Definitions {#automation-definitions}
 
 <pre highlight="cddl" class="cddl" data-cddl-module="remote-cddl,local-cddl" export>
 UserAgentClientHintsCommand = (
-  emulation.SetClientHintsOverrideCommand
+  userAgentClientHints.SetClientHintsOverrideCommand
 )
 </pre>
 
@@ -1082,28 +1082,28 @@ A [=User agent=] has <dfn>emulated client hints</dfn>, which is a [=struct=] wit
 * [=struct/item=] named <dfn for="emulated client hints" export>emulated client hints per navigables</dfn>,
     which is a weak map between [=/navigables=] and [=user agent client hints=], initially empty.
 
-The emulation.setClientHintsOverride command {#emulation-setclienthintsoverride}
+The userAgentClientHints.setClientHintsOverride command {#emulation-setclienthintsoverride}
 ----------------
 
-The <dfn export for=commands>emulation.setClientHintsOverride</dfn> command sets or removes
+The <dfn export for=commands>userAgentClientHints.setClientHintsOverride</dfn> command sets or removes
 emulated user agent client hints for a list of [=/navigables=] or [=user context=], or globally.
 
 <dl>
    <dt>Command Type</dt>
    <dd>
     <pre class="cddl" data-cddl-module="remote-cddl" export>
-        emulation.SetClientHintsOverrideCommand = {
-            method: "emulation.setClientHintsOverride",
+        userAgentClientHints.SetClientHintsOverrideCommand = {
+            method: "userAgentClientHints.setClientHintsOverride",
             params: {
-                clientHints: emulation.ClientHintsMetadata / null,
+                clientHints: userAgentClientHints.ClientHintsMetadata / null,
                 ? contexts: [+text],
                 ? userContexts: [+text],
             }
         }
 
-        emulation.ClientHintsMetadata = {
-            ? brands: [* emulation.BrandVersion],
-            ? fullVersionList: [* emulation.BrandVersion],
+        userAgentClientHints.ClientHintsMetadata = {
+            ? brands: [* userAgentClientHints.BrandVersion],
+            ? fullVersionList: [* userAgentClientHints.BrandVersion],
             ? platform: text,
             ? platformVersion: text,
             ? architecture: text,
@@ -1114,7 +1114,7 @@ emulated user agent client hints for a list of [=/navigables=] or [=user context
             ? formFactors: [* text];
         }
 
-        emulation.BrandVersion = {
+        userAgentClientHints.BrandVersion = {
             brand: text,
             version: text
         }
@@ -1123,7 +1123,7 @@ emulated user agent client hints for a list of [=/navigables=] or [=user context
    <dt>Return Type</dt>
    <dd>
       <pre class="cddl" data-cddl-module="local-cddl" export>
-      emulation.SetClientHintsOverrideResult = {}
+      userAgentClientHints.SetClientHintsOverrideResult = {}
       </pre>
    </dd>
 </dl>
@@ -1159,7 +1159,7 @@ The <dfn export>emulated UA Client Hints</dfn> associated with [=environment set
 
 </div>
 
-<div algorithm="remote end steps for emulation.setClientHintsOverride">
+<div algorithm="remote end steps for userAgentClientHints.setClientHintsOverride">
 
 The [=remote end steps=] given |command parameters| are:
 

--- a/index.bs
+++ b/index.bs
@@ -468,11 +468,6 @@ has defined a number of properties for itself:
       any other [=equivalence classes=] full version).
 *   <dfn for="user agent" export>wow64-ness</dfn> - A boolean indicating if the [=user agent=]'s binary is running in 32-bit mode on 64-bit Windows. (e.g., ?0 or ?1)
 
-Whenever the Client Hints are requested for the given [=environment settings object=],
-|environment settings|, if [=emulated UA Client Hints=] associated with the |environment settings|
-is not null, return the corresponding value from the [=emulated UA Client Hints=] instead of the
-default value for the requested property.
-
 [=User agents=] SHOULD keep these strings short and to the point, but servers MUST accept arbitrary
 values for each, as they are all values constructed at the [=user agent=]'s whim.
 
@@ -500,9 +495,18 @@ privacy, compatibility, or other reasons, given a request for any the following 
 [=user agent/full version=], [=user agent/platform architecture=], [=user agent/platform bitness=],
 [=user agent/wow64-ness=] or [=user agent/model=].
 
-If the [=user agent=]'s [=emulated client hints=] is not null, the [=user agent=] MUST
-return the corresponding value from the [=emulated client hints=] instead of the default
-value for the requested property.
+<div algorithm="accessing client hints properties">
+Whenever the Client Hints property |property| is requested for the given [=environment settings object=]
+|environment settings|, run the following steps:
+
+1. Let |emulated client hints| be [=emulated UA Client Hints=] associated with for |environment settings|.
+
+1. If |emulated client hints| is not null and |emulated client hints|'s |property| is not undefined,
+    return |emulated client hints|'s |property|.
+
+1. Return the implementation-defined value of |property|.
+
+</div>
 
 The 'Sec-CH-UA' Header Field {#sec-ch-ua}
 ----------------------------
@@ -1043,6 +1047,8 @@ The <dfn method for="NavigatorUA"><code>toJSON()</code></dfn> method MUST run th
 Automation {#automation}
 ========================
 
+For the purposes of user-agent automation and application testing, this document defines extensions to the [[WebDriver-BiDi]] specification.
+
 Definitions {#automation-definitions}
 ----------------------
 
@@ -1057,22 +1063,16 @@ A <dfn>brand version</dfn> is a [=struct=] with:
 * [=struct/item=] named <dfn for="brand version" export>version</dfn>, which is a string.
 
 An <dfn>user agent client hints</dfn> is a [=struct=] with:
-* [=struct/item=] named <dfn for="user agent client hints" export>brands</dfn>, which is a list of
-    [=brand version=] pairs or null;
-* [=struct/item=] named <dfn for="user agent client hints" export>full version</dfn>, which is a string or
-    null;
-* [=struct/item=] named <dfn for="user agent client hints" export>full version list</dfn>, which is a list
-    of [=brand version=] or null;
-* [=struct/item=] named <dfn for="user agent client hints" export>mobile</dfn>, which is a boolean or null;
-* [=struct/item=] named <dfn for="user agent client hints" export>model</dfn>, which is a string or null;
-* [=struct/item=] named <dfn for="user agent client hints" export>platform</dfn>, which is a string or
-    null;
-* [=struct/item=] named <dfn for="user agent client hints" export>platform version</dfn>, which is a string
-    or null;
-* [=struct/item=] named <dfn for="user agent client hints" export>architecture</dfn>, which is a string or
-    null;
-* [=struct/item=] named <dfn for="user agent client hints" export>bitness</dfn>, which is a string or null;
-* [=struct/item=] named <dfn for="user agent client hints" export>wow64</dfn>, which is a boolean or null.
+* [=struct/item=] named <dfn for="user agent client hints" export>brands</dfn>, which is a list of[=brand version=] pairs or undefined, initially undefined;
+* [=struct/item=] named <dfn for="user agent client hints" export>full version</dfn>, which is a string or undefined, initially undefined;
+* [=struct/item=] named <dfn for="user agent client hints" export>full version list</dfn>, which is a list of [=brand version=] or undefined, initially undefined;
+* [=struct/item=] named <dfn for="user agent client hints" export>mobile</dfn>, which is a boolean or undefined, initially undefined;
+* [=struct/item=] named <dfn for="user agent client hints" export>model</dfn>, which is a string or undefined, initially undefined;
+* [=struct/item=] named <dfn for="user agent client hints" export>platform</dfn>, which is a string or undefined, initially undefined;
+* [=struct/item=] named <dfn for="user agent client hints" export>platform version</dfn>, which is a string or undefined, initially undefined;
+* [=struct/item=] named <dfn for="user agent client hints" export>architecture</dfn>, which is a string or undefined, initially undefined;
+* [=struct/item=] named <dfn for="user agent client hints" export>bitness</dfn>, which is a string or undefined, initially undefined;
+* [=struct/item=] named <dfn for="user agent client hints" export>wow64</dfn>, which is a boolean or undefined, initially undefined.
 
 A [=User agent=] has <dfn>emulated client hints</dfn>, which is a [=struct=] with:
 * [=struct/item=] named <dfn for="emulated client hints" export>default emulated client hints</dfn>, which

--- a/index.bs
+++ b/index.bs
@@ -59,6 +59,9 @@ urlPrefix: https://w3c.github.io/webdriver-bidi/; spec: webdriver-bidi
         text: user context; url: #user-context
         text: get valid top-level traversables by ids; url: #get-valid-top-level-traversables-by-ids
         text: get valid user contexts; url: #get-valid-user-contexts
+urlPrefix: https://w3c.github.io/webdriver/; spec: webdriver
+    type: dfn
+        text: remote end; url: #dfn-remote-ends
 
 </pre>
 <pre class="biblio">
@@ -1074,9 +1077,9 @@ An <dfn>user agent client hints</dfn> is a [=struct=] with:
 * [=struct/item=] named <dfn for="user agent client hints" export>bitness</dfn>, which is a string or undefined, initially undefined;
 * [=struct/item=] named <dfn for="user agent client hints" export>wow64</dfn>, which is a boolean or undefined, initially undefined.
 
-A [=User agent=] has <dfn>emulated client hints</dfn>, which is a [=struct=] with:
-* [=struct/item=] named <dfn for="emulated client hints" export>default emulated client hints</dfn>, which
-    is an [=user agent client hints=] or null, initially null;
+A [=remote end=] has associated <dfn>emulated client hints</dfn>, which is a [=struct=] with:
+* [=struct/item=] named <dfn for="emulated client hints" export>default emulated client hints</dfn>,
+    which is a [=user agent client hints=] or null, initially null;
 * [=struct/item=] named <dfn for="emulated client hints" export>emulated client hints per user contexts</dfn>,
     which is a weak map between [=user context=] and [=user agent client hints=], initially empty;
 * [=struct/item=] named <dfn for="emulated client hints" export>emulated client hints per navigables</dfn>,


### PR DESCRIPTION
Addressing https://github.com/WICG/ua-client-hints/issues/391 by moving command to a dedicated `userAgentClientHints` domain.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sadym-chromium/ua-client-hints/pull/393.html" title="Last updated on Feb 9, 2026, 9:54 AM UTC (e85e188)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/ua-client-hints/393/4aa9d53...sadym-chromium:e85e188.html" title="Last updated on Feb 9, 2026, 9:54 AM UTC (e85e188)">Diff</a>